### PR TITLE
Fix UnicodeEncodeError on Windows

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -287,11 +287,11 @@ def cli():
         )
 
         # save TXT
-        with open(os.path.join(output_dir, audio_path + ".txt"), "w") as txt:
+        with open(os.path.join(output_dir, audio_path + ".txt"), "w", encoding="utf-8") as txt:
             print(result["text"], file=txt)
 
         # save VTT
-        with open(os.path.join(output_dir, audio_path + ".vtt"), "w") as vtt:
+        with open(os.path.join(output_dir, audio_path + ".vtt"), "w", encoding="utf-8") as vtt:
             write_vtt(result["segments"], file=vtt)
 
 


### PR DESCRIPTION
On Windows, Python uses text encodings like Windows-1252 by default, which can sometimes cause `UnicodeEncodeError`s if the output contains certain characters.
This can be fixed by explicitly setting the encoding to UTF-8.
UTF-8 encoding is also required by the WebVTT spec: https://www.w3.org/TR/webvtt1/#file-structure