### PR TITLE
Fix output_dir argument when audio file is a path

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -286,12 +286,14 @@ def cli():
             **args,
         )
 
+        audio_basename = os.path.basename(audio_path)
+
         # save TXT
-        with open(os.path.join(output_dir, audio_path + ".txt"), "w") as txt:
+        with open(os.path.join(output_dir, audio_basename + ".txt"), "w") as txt:
             print(result["text"], file=txt)
 
         # save VTT
-        with open(os.path.join(output_dir, audio_path + ".vtt"), "w") as vtt:
+        with open(os.path.join(output_dir, audio_basename + ".vtt"), "w") as vtt:
             write_vtt(result["segments"], file=vtt)
 
 


### PR DESCRIPTION
If you specify the audio as a path ("D:\Files\Audio.flac" instead of simply "Audio.flac") the output_dir argument does not actually function. It creates a new folder where it's supposed to, but the files are not actually placed there. They are placed in the same folder the audio file resides.

This happens because `os.path.join` is used to join `output_dir` and `audio_path`, which of course won't work if both of those variables contain full paths.

The issue is easily fixed by passing `audio_path` through the `os.path.basename` method before it is combined with `output_dir` to ensure it is always just the filename of the audio.