### PR TITLE
Fix possible mistake when loading model to device

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -273,7 +273,7 @@ def cli():
         temperature = [temperature]
 
     from . import load_model
-    model = load_model(model_name).to(device)
+    model = load_model(model_name, device=device)
 
     for audio_path in args.pop("audio"):
         result = transcribe(


### PR DESCRIPTION
Before this little change, the model is loaded into GPU regardless of the value of "device" argument in CLI.

(e.g. whisper "test.wav" --device CPU loads into GPU anyway)