### PR TITLE
Adds missing command for install (mac)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ choco install ffmpeg
 scoop install ffmpeg
 ```
 
-You may need [`rust`](http://rust-lang.org) installed as well, in case [tokenizers](https://pypi.org/project/tokenizers/) does not provide a pre-built wheel for your platform. If you see installation errors during the `pip install` command above, please follow the [Getting started page](https://www.rust-lang.org/learn/get-started) to install Rust development environment.
+You may need [`rust`](http://rust-lang.org) installed as well, in case [tokenizers](https://pypi.org/project/tokenizers/) does not provide a pre-built wheel for your platform. If you see installation errors during the `pip install` command above, please follow the [Getting started page](https://www.rust-lang.org/learn/get-started) to install Rust development environment & set `export PATH="$HOME/.cargo/bin:$PATH"`.
 
 
 ## Available models and languages

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ choco install ffmpeg
 scoop install ffmpeg
 ```
 
-You may need [`rust`](http://rust-lang.org) installed as well, in case [tokenizers](https://pypi.org/project/tokenizers/) does not provide a pre-built wheel for your platform. If you see installation errors during the `pip install` command above, please follow the [Getting started page](https://www.rust-lang.org/learn/get-started) to install Rust development environment & set `export PATH="$HOME/.cargo/bin:$PATH"`.
+You may need [`rust`](http://rust-lang.org) installed as well, in case [tokenizers](https://pypi.org/project/tokenizers/) does not provide a pre-built wheel for your platform. If you see installation errors during the `pip install` command above, please follow the [Getting started page](https://www.rust-lang.org/learn/get-started) to install Rust development environment. Additionally, you may need to configure the `PATH` environment variable, e.g. `export PATH="$HOME/.cargo/bin:$PATH"`.
 
 
 ## Available models and languages


### PR DESCRIPTION
Required for users who didn't previously have Rust installed.
Instructions from #30 were insufficient without more google search on how to install. Answer found on [tokenizers page](https://pypi.org/project/tokenizers/#:~:text=To%20use%20this%20method%2C%20you%20need%20to%20have%20the%20Rust%20installed%3A)