### PR TITLE
simplify package installation by removing ffmpeg cli install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,25 +17,9 @@ A Transformer sequence-to-sequence model is trained on various speech processing
 
 ## Setup
 
-We used Python 3.9.9 and [PyTorch](https://pytorch.org/) 1.10.1 to train and test our models, but the codebase is expected to be compatible with Python 3.7 or later and recent PyTorch versions. The codebase also depends on a few Python packages, most notably [HuggingFace Transformers](https://huggingface.co/docs/transformers/index) for their fast tokenizer implementation and [ffmpeg-python](https://github.com/kkroening/ffmpeg-python) for reading audio files. The following command will pull and install the latest commit from this repository, along with its Python dependencies 
+We used Python 3.9.9 and [PyTorch](https://pytorch.org/) 1.10.1 to train and test our models, but the codebase is expected to be compatible with Python 3.7 or later and recent PyTorch versions. The codebase also depends on a few Python packages, most notably [HuggingFace Transformers](https://huggingface.co/docs/transformers/index) for their fast tokenizer implementation and [moviepy](https://github.com/Zulko/moviepy) for reading audio files. The following command will pull and install the latest commit from this repository, along with its Python dependencies 
 
     pip install git+https://github.com/openai/whisper.git 
-
-It also requires the command-line tool [`ffmpeg`](https://ffmpeg.org/) to be installed on your system, which is available from most package managers:
-
-```bash
-# on Ubuntu or Debian
-sudo apt update && sudo apt install ffmpeg
-
-# on MacOS using Homebrew (https://brew.sh/)
-brew install ffmpeg
-
-# on Windows using Chocolatey (https://chocolatey.org/)
-choco install ffmpeg
-
-# on Windows using Scoop (https://scoop.sh/)
-scoop install ffmpeg
-```
 
 You may need [`rust`](http://rust-lang.org) installed as well, in case [tokenizers](https://pypi.org/project/tokenizers/) does not provide a pre-built wheel for your platform. If you see installation errors during the `pip install` command above, please follow the [Getting started page](https://www.rust-lang.org/learn/get-started) to install Rust development environment.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ torch
 tqdm
 more-itertools
 transformers>=4.19.0
-ffmpeg-python==0.2.0
+moviepy==1.0.3

--- a/whisper/audio.py
+++ b/whisper/audio.py
@@ -40,7 +40,7 @@ def load_audio(file: str, sr: int = SAMPLE_RATE):
     # fps: ar
     # nchannels=1: ac=1
     # nbytes=2: format=s16le & acodec=pcm_s16le
-    reader = FFMPEG_AudioReader(file, fps=sr, nbytes=2, buffersize=2000000, nchannels=1)
+    reader = FFMPEG_AudioReader(file, fps=sr, nbytes=2, buffersize=float('inf'), nchannels=1)
 
     if reader.buffer.shape[0] == 0:
         raise RuntimeError(f"Failed to load audio: {file}")

--- a/whisper/audio.py
+++ b/whisper/audio.py
@@ -39,7 +39,7 @@ def load_audio(file: str, sr: int = SAMPLE_RATE):
 
     # fps: ar
     # nchannels=1: ac=1
-    # nbytes=2: format=s16le&acodec=pcm_s16le
+    # nbytes=2: format=s16le & acodec=pcm_s16le
     reader = FFMPEG_AudioReader(file, fps=sr, nbytes=2, buffersize=2000000, nchannels=1)
 
     if reader.buffer.shape[0] == 0:


### PR DESCRIPTION
**edit:** you no longer have to accept this PR, just created a new package including this feature: https://github.com/fcakyon/pywhisper

This PR reaplaces `ffmpeg cli tool` + `ffmpeg-python package` with `moviepy package` without any difference in audio waveform values.

This PR removes the external cli tool dependency and simplifies installation since pip install would be enough.

I have tested with `tests/jfk.flac` file and `load_audio()` output is exactly same as before:

```python
dtype: dtype('float32')
max: 0.78271484
min: -0.7235718
shape: (176000,)
size: 176000
```

Also tested with a 1h43min video, works without any issues.

moviepy: https://github.com/Zulko/moviepy