### PR TITLE
Write each sentence as a separate line for the txt output

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -9,7 +9,7 @@ import torch
 from .audio import SAMPLE_RATE, N_FRAMES, HOP_LENGTH, pad_or_trim, log_mel_spectrogram
 from .decoding import DecodingOptions, DecodingResult
 from .tokenizer import LANGUAGES, TO_LANGUAGE_CODE, get_tokenizer
-from .utils import exact_div, format_timestamp, optional_int, optional_float, str2bool, write_vtt
+from .utils import exact_div, format_timestamp, optional_int, optional_float, str2bool, write_txt, write_vtt
 
 if TYPE_CHECKING:
     from .model import Whisper
@@ -278,7 +278,7 @@ def cli():
 
         # save TXT
         with open(os.path.join(output_dir, audio_basename + ".txt"), "w", encoding="utf-8") as txt:
-            print(result["text"], file=txt)
+            write_txt(result["segments"], file=txt)
 
         # save VTT
         with open(os.path.join(output_dir, audio_basename + ".vtt"), "w", encoding="utf-8") as vtt:

--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -42,6 +42,13 @@ def format_timestamp(seconds: float):
 
     return (f"{hours}:" if hours > 0 else "") + f"{minutes:02d}:{seconds:02d}.{milliseconds:03d}"
 
+def write_txt(transcript: Iterator[dict], file: TextIO):
+    for segment in transcript:
+        print(
+            f"{segment['text'].strip()}",
+            file=file,
+            flush=True,
+        )
 
 def write_vtt(transcript: Iterator[dict], file: TextIO):
     print("WEBVTT\n", file=file)

--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -43,13 +43,11 @@ def format_timestamp(seconds: float, always_include_hours: bool = False):
     hours_marker = f"{hours}:" if always_include_hours or hours > 0 else ""
     return f"{hours_marker}{minutes:02d}:{seconds:02d}.{milliseconds:03d}"
 
+
 def write_txt(transcript: Iterator[dict], file: TextIO):
     for segment in transcript:
-        print(
-            f"{segment['text'].strip()}",
-            file=file,
-            flush=True,
-        )
+        print(segment['text'].strip(), file=file, flush=True)
+
 
 def write_vtt(transcript: Iterator[dict], file: TextIO):
     print("WEBVTT\n", file=file)


### PR DESCRIPTION
Currently all sentences are glued together when they are written to the txt file the app outputs. 

I don't see any use case where that is more convenient than having the sentences written on their own line.

If this was done with some specific intent, and there is a use case I'm not aware of, then feel free to close this PR.