### PR TITLE
add srt subtitle export utility

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -10,7 +10,7 @@ import tqdm
 from .audio import SAMPLE_RATE, N_FRAMES, HOP_LENGTH, pad_or_trim, log_mel_spectrogram
 from .decoding import DecodingOptions, DecodingResult
 from .tokenizer import LANGUAGES, TO_LANGUAGE_CODE, get_tokenizer
-from .utils import exact_div, format_timestamp, optional_int, optional_float, str2bool, write_vtt
+from .utils import exact_div, format_timestamp, optional_int, optional_float, str2bool, write_vtt, write_srt
 
 if TYPE_CHECKING:
     from .model import Whisper
@@ -300,6 +300,10 @@ def cli():
         # save VTT
         with open(os.path.join(output_dir, audio_basename + ".vtt"), "w", encoding="utf-8") as vtt:
             write_vtt(result["segments"], file=vtt)
+
+        # save SRT
+        with open(os.path.join(output_dir, audio_basename + ".srt"), "w", encoding="utf-8") as srt:
+            write_srt(result["segments"], file=srt)
 
 
 if __name__ == '__main__':

--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -52,3 +52,49 @@ def write_vtt(transcript: Iterator[dict], file: TextIO):
             file=file,
             flush=True,
         )
+
+def format_timestamp_for_srt(seconds: float):
+    assert seconds >= 0, "non-negative timestamp expected"
+    milliseconds = round(seconds * 1000.0)
+
+    hours = milliseconds // 3_600_000
+    milliseconds -= hours * 3_600_000
+
+    minutes = milliseconds // 60_000
+    milliseconds -= minutes * 60_000
+
+    seconds = milliseconds // 1_000
+    milliseconds -= seconds * 1_000
+
+    # hour is necessary for srt
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d},{milliseconds:03d}"
+
+
+def write_srt(transcript: Iterator[dict], file: TextIO):
+    """
+    Write a transcript to a file in SRT format.
+
+    Example usage:
+        from pathlib import Path
+        from whisper.utils import write_srt
+
+        result = transcribe(model, audio_path, temperature=temperature, **args)
+
+        # save SRT
+        audio_basename = Path(audio_path).stem
+        with open(Path(output_dir) / (audio_basename + ".srt"), "w", encoding="utf-8") as srt:
+            write_srt(result["segments"], file=srt)
+    """
+    for ind, segment in enumerate(transcript):
+        # remove space at the start of the text
+        if segment['text'][0] == ' ':
+            segment['text'] = segment['text'][1:]
+
+        # write srt lines
+        print(f"{ind+1}", file=file)
+        print(
+            f"{format_timestamp_for_srt(segment['start'])} --> {format_timestamp_for_srt(segment['end'])}\n"
+            f"{segment['text'].replace('-->', '->')}\n",
+            file=file,
+            flush=True,
+        )


### PR DESCRIPTION
**edit:** you no longer have to accept this PR, just created a new package including this feature: https://github.com/fcakyon/pywhisper

Currently, transcribed text can be exported only as TXT or VTT.

This PR adds utility for exporting transcription results in SRT subtitle format.

reference: https://en.wikipedia.org/wiki/SubRip