### PR TITLE
Fix cli token suppression list parsing.

### DIFF
--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -537,8 +537,7 @@ class DecodingTask:
         elif suppress_tokens is None or len(suppress_tokens) == 0:
             suppress_tokens = []  # interpret empty string as an empty list
         else:
-            assert isinstance(self.options.suppress_tokens, list), "suppress_tokens must be a list"
-            suppress_tokens = self.options.suppress_tokens
+            assert isinstance(suppress_tokens, list), "suppress_tokens must be a list"
 
         suppress_tokens.extend(
             [self.tokenizer.sot, self.tokenizer.sot_prev, self.tokenizer.sot_lm]


### PR DESCRIPTION
Providing a list for token suppression (´--suppress_tokens="12681, 3081, 301"´) would always cause ´AssertionError: suppress_tokens must be a list´.

The string was first parsed to a list, then the original string was typechecked for list type. This cannot possibly succeed.