### PR TITLE
Add section for listing community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ result = whisper.decode(model, mel, options)
 print(result.text)
 ```
 
+## Extensions and integrations
+
+A list of community-contributed extended functionality and integrations with whisper.
+
++ [Whisper mic](https://github.com/mallorbc/whisper_mic/) Allows to use use a microphone continuously.
++ [Whispering](https://github.com/shirayu/whispering/) Streaming transcriber. Enables acess through webserver.
+
+
 ## License
 
 The code and the model weights of Whisper are released under the MIT License. See [LICENSE](LICENSE) for further details.


### PR DESCRIPTION
Last pull request had a typo. In the meanwhile added a new extension that was contributed.

The goal is to have a section where the community can find practical usage of whisper for different situations.
Instead of reinventing the wheel, we can check what is already available and either reuse and/or help them.