### PR TITLE
Context prompt cli option

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -160,6 +160,12 @@ def transcribe(
         if verbose:
             print(f"[{format_timestamp(start)} --> {format_timestamp(end)}] {text}")
 
+    if isinstance((start_prompt := decode_options["prompt"]), str):
+        print(f"{start_prompt=}")
+        all_tokens.extend(
+            tokenizer.encode(" " + start_prompt.strip())
+        )
+
     while seek < mel.shape[-1]:
         timestamp_offset = float(seek * HOP_LENGTH / SAMPLE_RATE)
         segment = pad_or_trim(mel[:, :, seek:], N_FRAMES).to(model.device).to(dtype)
@@ -250,6 +256,7 @@ def cli():
     parser.add_argument("--length_penalty", type=float, default=None, help="optional token length penalty coefficient (alpha) as in https://arxiv.org/abs/1609.08144, uses simple lengt normalization by default")
 
     parser.add_argument("--suppress_tokens", type=str, default="-1", help="comma-separated list of token ids to suppress during sampling; '-1' will suppress most special characters except common punctuations")
+    parser.add_argument("--prompt", type=str, default=None, help="optional text to provide as a prompt for the first window.")
     parser.add_argument("--condition_on_previous_text", type=str2bool, default=True, help="if True, provide the previous output of the model as a prompt for the next window; disabling may make the text inconsistent across windows, but the model becomes less prone to getting stuck in a failure loop")
     parser.add_argument("--fp16", type=str2bool, default=True, help="whether to perform inference in fp16; True by default")
 


### PR DESCRIPTION
Add --prompt "context" option to lead in the transcription. This can be used to introduce proper names or indicate a technical context. 