### PR TITLE
Use PyTorch as logits transpose for ONNX support

### DIFF
--- a/whisper/model.py
+++ b/whisper/model.py
@@ -189,7 +189,7 @@ class TextDecoder(nn.Module):
             x = block(x, xa, mask=self.mask, kv_cache=kv_cache)
 
         x = self.ln(x)
-        logits = (x @ self.token_embedding.weight.to(x.dtype).T).float()
+        logits = (x @ torch.transpose(self.token_embedding.weight.to(x.dtype), 0, 1)).float()
 
         return logits
 


### PR DESCRIPTION
Because Numpy was used for the final transpose for the logits output, `torch.onnx.export` would fail
```
/usr/local/lib/python3.7/dist-packages/torch/onnx/utils.py in _run_symbolic_function(g, block, n, inputs, env, operator_export_type)
   1420         else:
   1421             raise symbolic_registry.UnsupportedOperatorError(
-> 1422                 domain, op_name, opset_version
   1423             )
   1424     except RuntimeError:
UnsupportedOperatorError: Exporting the operator ::numpy_T to ONNX opset version 13 is not supported. Please feel free to request support or submit a pull request on PyTorch GitHub.
```

If this line at whisper/model.py:L192 is changed from
`logits = (x @ self.token_embedding.weight.to(x.dtype).T).float()`
to
`logits = (x @ torch.transpose(self.token_embedding.weight.to(x.dtype), 0, 1)).float()`
then the export succeeds!

Code to test export:
```lang=python
import whisper
import torch

tiny_model = whisper.load_model("tiny")
torch.onnx.export(tiny_model.encoder, torch.randn(1,80,3000).to("cuda"), "tiny/whisper-encoder.onnx")
torch.onnx.export(tiny_model.decoder, (torch.tensor([[50258]]).to("cuda"), torch.randn(1,384,384).to("cuda")), "tiny/whisper-decoder_main.onnx")
torch.onnx.export(tiny_model.decoder, (torch.tensor([[50258, 50259, 50359]]).to("cuda"), torch.randn(1, 384, 384).to("cuda")), "tiny/whisper-decoder_language.onnx")
```