### PR TITLE
add '-nostdin' argument when running ffmpeg

### DIFF
--- a/whisper/audio.py
+++ b/whisper/audio.py
@@ -41,7 +41,7 @@ def load_audio(file: str, sr: int = SAMPLE_RATE):
         out, _ = (
             ffmpeg.input(file, threads=0)
             .output("-", format="s16le", acodec="pcm_s16le", ac=1, ar=sr)
-            .run(cmd="ffmpeg", capture_stdout=True, capture_stderr=True)
+            .run(cmd=["ffmpeg", "-nostdin"], capture_stdout=True, capture_stderr=True)
         )
     except ffmpeg.Error as e:
         raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e


### PR DESCRIPTION
ffmpeg subprocess suspends when executed in the background.
Please see https://ffmpeg.org/pipermail/ffmpeg-user/2017-November/037754.html
This pull request is a workaround.