### PR TITLE
Don't update duration if last timestamp is timestamp_begin

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -220,7 +220,7 @@ def transcribe(
             else:
                 duration = segment_duration
                 timestamps = tokens[timestamp_tokens.nonzero().flatten()]
-                if len(timestamps) > 0:
+                if len(timestamps) > 0 and timestamps[-1].item() != tokenizer.timestamp_begin:
                     # no consecutive timestamps but it has a timestamp; use the last one.
                     # single timestamp at the end means no speech after the last timestamp.
                     last_timestamp_position = timestamps[-1].item() - tokenizer.timestamp_begin


### PR DESCRIPTION
There is bug causing start and end timestamps of the segments to be same when they shouldn't be.
If the only timestamp-token found is the `tokenizer.timestamp_begin` then we shouldn't update the duration (to 0). If there is really no speech, then anyway the segment won't be appended by the `add_segment` function.
Before this fix:
![image](https://user-images.githubusercontent.com/5212929/193052332-4b3215df-efcc-49d1-861f-27983cc3f3ec.png)
After this fix:
![image](https://user-images.githubusercontent.com/5212929/193052475-a5214c1e-a295-4896-83e3-273d05d355c5.png)
