### PR TITLE
Fix timestamps and strip extraneous whitespace in WebVTT output

### DIFF
--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -40,7 +40,7 @@ def format_timestamp(seconds: float, always_include_hours: bool = False, decimal
     seconds = milliseconds // 1_000
     milliseconds -= seconds * 1_000
 
-    hours_marker = f"{hours}:" if always_include_hours or hours > 0 else ""
+    hours_marker = f"{hours:02d}:" if always_include_hours or hours > 0 else ""
     return f"{hours_marker}{minutes:02d}:{seconds:02d}{decimal_marker}{milliseconds:03d}"
 
 

--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -54,7 +54,7 @@ def write_vtt(transcript: Iterator[dict], file: TextIO):
     for segment in transcript:
         print(
             f"{format_timestamp(segment['start'])} --> {format_timestamp(segment['end'])}\n"
-            f"{segment['text'].replace('-->', '->')}\n",
+            f"{segment['text'].strip().replace('-->', '->')}\n",
             file=file,
             flush=True,
         )


### PR DESCRIPTION
YouTube won’t accept the generated .vtt files if there are any timestamps beyond an hour, because the hour field isn’t formatted correctly. It also shows extraneous whitespace around the segment text because we’re not stripping it. This PR fixes both problems.