### PR TITLE
Reuse initial prompt after prompt reset

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -175,6 +175,8 @@ def transcribe(
             segment_duration = segment.shape[-1] * HOP_LENGTH / SAMPLE_RATE
 
             decode_options["prompt"] = all_tokens[prompt_reset_since:]
+            if len(decode_options["prompt"]) == 0 and initial_prompt and condition_on_previous_text:
+                decode_options["prompt"] = initial_prompt
             result: DecodingResult = decode_with_fallback(segment)
             tokens = torch.tensor(result.tokens)
 


### PR DESCRIPTION
This should solve #194, I think. If the temperature gets too high and the prompt tokens are reset, use the initial prompt to nudge Whisper towards a certain transcription style.