### PR TITLE
Fixed CoW RuntimeError in DecodingTask.run()

### DIFF
--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -615,7 +615,7 @@ class DecodingTask:
         n_audio: int = mel.shape[0]
 
         audio_features: Tensor = self._get_audio_features(mel)  # encoder forward pass
-        tokens: Tensor = torch.tensor([self.initial_tokens]).expand(n_audio, -1)
+        tokens: Tensor = torch.tensor([self.initial_tokens]).repeat(n_audio, 1)
 
         # detect language if requested, overwriting the language token
         languages, language_probs = self._detect_language(audio_features, tokens)


### PR DESCRIPTION
To reproduce:
```
import whisper
import torch

model = whisper.load_model("tiny", device="cuda")
options = whisper.DecodingOptions(without_timestamps=True, fp16=True)
mels = torch.stack([torch.randn(80, 3000, device="cuda") for _ in range(10)])
with torch.no_grad():
    outputs = model.decode(mels, options)
```
Gives
```
tokens[:, self.sot_index + 1] = lang_tokens  # write language tokens
RuntimeError: unsupported operation: more than one element of the written-to tensor refers to a single memory location. Please clone() the tensor before performing the operation.
```

Replacing the expand by a repeat (or calling clone() after expand) solves the issue