### PR TITLE
Update README to include instructions for .en models

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ print(result["text"])
 
 Internally, the `transcribe()` method reads the entire file and processes the audio with a sliding 30-second window, performing autoregressive sequence-to-sequence predictions on each window.
 
+The `transcribe()` method requires the argument `language="en"` when using `.en` models:
+
+```python
+import whisper
+
+model = whisper.load_model("medium.en")
+result = model.transcribe("audio.mp3", language="en")
+print(result["text"])
+```
+
 Below is an example usage of `whisper.detect_language()` and `whisper.decode()` which provide lower-level access to the model.
 
 ```python


### PR DESCRIPTION
Using the method `model.transcribe("audio.wav")` with `.en` models (`tiny.en`, `base.en`, `small.en`, `medium.en`) results in the error:
```
ValueError: This model doesn't have language tokens so it can't perform lang id
```

The method needs to be called with an additional argument `language="en"` for `.en` models:
`model.transcribe("audio.mp3", language="en")`

This PR adds this specific instruction to the README for clarity and help to others using these models.