### PR TITLE
infer download_root from XDG_CACHE_HOME if avail

### DIFF
--- a/whisper/__init__.py
+++ b/whisper/__init__.py
@@ -90,7 +90,10 @@ def load_model(name: str, device: Optional[Union[str, torch.device]] = None, dow
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
     if download_root is None:
-        download_root = os.path.join(os.path.expanduser("~"), ".cache", "whisper")
+        download_root = os.getenv(
+            "XDG_CACHE_HOME", 
+            os.path.join(os.path.expanduser("~"), ".cache", "whisper")
+        )
 
     if name in _MODELS:
         checkpoint_file = _download(_MODELS[name], download_root, in_memory)


### PR DESCRIPTION
This PR facilitates user-specified override download location for model checkpoints.

The environment variable `XDG_CACHE_HOME` defaults to the user cache (`~/.cache`) and is widely adopted for specifying checkpoint download locations across the pytorch ecosystem, see for example how it is used by [huggingface](https://github.com/huggingface/diffusers/blob/main/src/diffusers/utils/__init__.py#L50) and [torch.hub](https://github.com/pytorch/pytorch/blob/c6348a7109796887d6497ed4c463537016003c39/torch/hub.py#L74). 

Details regarding this and related environment variables can be found here: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html