### PR TITLE
Bound end timestamps by length of audio input

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -201,8 +201,9 @@ def transcribe(
                     start_timestamp_position = (
                         sliced_tokens[0].item() - tokenizer.timestamp_begin
                     )
-                    end_timestamp_position = (
-                        sliced_tokens[-1].item() - tokenizer.timestamp_begin
+                    end_timestamp_position = min(
+                        sliced_tokens[-1].item() - tokenizer.timestamp_begin,
+                        np.ceil((num_frames - seek) / input_stride) - 1
                     )
                     add_segment(
                         start=timestamp_offset + start_timestamp_position * time_precision,
@@ -222,7 +223,10 @@ def transcribe(
                 if len(timestamps) > 0 and timestamps[-1].item() != tokenizer.timestamp_begin:
                     # no consecutive timestamps but it has a timestamp; use the last one.
                     # single timestamp at the end means no speech after the last timestamp.
-                    last_timestamp_position = timestamps[-1].item() - tokenizer.timestamp_begin
+                    last_timestamp_position = min(
+                        timestamps[-1].item() - tokenizer.timestamp_begin,
+                        np.ceil((num_frames - seek) / input_stride) - 1
+                    )
                     duration = last_timestamp_position * time_precision
 
                 add_segment(


### PR DESCRIPTION
Add a post processing step to bound segment end timestamp by the length of the input, as discussed in [#124 (answer)](https://github.com/openai/whisper/discussions/124#discussioncomment-3733462)