### PR TITLE
Add package metadata to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,12 @@ setup(
     name="whisper",
     py_modules=["whisper"],
     version="1.0",
-    description="",
+    description="Robust Speech Recognition via Large-Scale Weak Supervision",
+    readme="README.md",
+    python_requires=">=3.7",
     author="OpenAI",
+    url="https://github.com/openai/whisper",
+    license="MIT",
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         str(r)


### PR DESCRIPTION
Add project summary, license, etc. to `whisper` project metadata for display when using "pip show" and similar Python package distribution tools.