### PR TITLE
Disabled '...' from being generated, since it often gets generated

### DIFF
--- a/whisper/tokenizer.py
+++ b/whisper/tokenizer.py
@@ -246,7 +246,7 @@ class Tokenizer:
         keeping basic punctuations like commas, periods, question marks, exclamation points, etc.
         """
         symbols = list("\"#()*+/:;<=>@[\\]^_`{|}~「」『』")
-        symbols += "<< >> <<< >>> -- --- -( -[ (' (\" (( )) ((( ))) [[ ]] {{ }} ♪♪ ♪♪♪".split()
+        symbols += "<< >> <<< >>> -- --- -( -[ (' (\" (( )) ((( ))) [[ ]] {{ }} ♪♪ ♪♪♪ ...".split()
 
         # symbols that may be a single token or multiple tokens depending on the tokenizer.
         # In case they're multiple tokens, suppress the first token, which is safe because:


### PR DESCRIPTION
Whisper often outputs "..." during short pauses in the middle of sentences and also often at the end of sentences & phrases. This is especially problematic when using many short phrases such as during live dictation or live conversations, it keeps inserting "..." roughly 1 or 2 times per sentence! Using the "prompt" above can reduce this but only by steering it significantly, but I imagine  most users don't ever want "..." in their results, so I recommend filtering out "..." completely.