### PR TITLE
Update Hebrew language code to he per IANA registry

### DIFF
--- a/whisper/tokenizer.py
+++ b/whisper/tokenizer.py
@@ -29,6 +29,7 @@ LANGUAGES = {
     "fi": "finnish",
     "vi": "vietnamese",
     "iw": "hebrew",
+    "he": "hebrew",
     "uk": "ukrainian",
     "el": "greek",
     "ms": "malay",

--- a/whisper/tokenizer.py
+++ b/whisper/tokenizer.py
@@ -28,7 +28,6 @@ LANGUAGES = {
     "hi": "hindi",
     "fi": "finnish",
     "vi": "vietnamese",
-    "iw": "hebrew",
     "he": "hebrew",
     "uk": "ukrainian",
     "el": "greek",


### PR DESCRIPTION
Per [IANA registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry), `iw` was deprecated as the code for Hebrew in 1989 and the preferred code is `he`

The correct subtag: 
```
%%
Type: language
Subtag: he
Description: Hebrew
Added: 2005-10-16
Suppress-Script: Hebr
%%
``` 
And the deprecation
```
%%
Type: language
Subtag: iw
Description: Hebrew
Added: 2005-10-16
Deprecated: 1989-01-01
Preferred-Value: he
Suppress-Script: Hebr
%%
```