### PR TITLE
Fix decoding error when mel is not given as encoded tensor

### DIFF
--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -40,7 +40,7 @@ def detect_language(model: "Whisper", mel: Tensor, tokenizer: Tokenizer = None) 
 
     # skip encoder forward pass if already-encoded audio features were given
     if mel.shape[-2:] != (model.dims.n_audio_ctx, model.dims.n_audio_state):
-        mel = model.encoder(mel)
+        mel = model.encoder(mel).last_hidden_state
 
     # forward pass using a single token, startoftranscript
     n_audio = mel.shape[0]
@@ -558,7 +558,7 @@ class DecodingTask:
             # encoded audio features are given; skip audio encoding
             audio_features = mel
         else:
-            audio_features = self.model.encoder(mel)
+            audio_features = self.model.encoder(mel).last_hidden_state
 
         if audio_features.dtype != (torch.float16 if self.options.fp16 else torch.float32):
             return TypeError(f"audio_features has an incorrect dtype: {audio_features.dtype}")


### PR DESCRIPTION
Error `AttributeError: 'EncoderOutput' object has no attribute 'shape'` is raised by default when not giving already-encoded audio features.

`model.encoder` returns `EncoderOutput` instead of the expected `torch.Tensor` by the rest of the code.  This raises error later in the code when trying to use functions that belong to `torch.Tensor`.

Can be reproduced with fresh clone from the git repository and using `whisper.transcribe(model, 'audio.wav')`.