### PR TITLE
Fix `compression_ratio` function

### DIFF
--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -24,7 +24,8 @@ def optional_float(string):
 
 
 def compression_ratio(text) -> float:
-    return len(text) / len(zlib.compress(text.encode("utf-8")))
+    text_bytes = text.encode("utf-8")
+    return len(text_bytes) / len(zlib.compress(text_bytes))
 
 
 def format_timestamp(seconds: float, always_include_hours: bool = False, decimal_marker: str = '.'):


### PR DESCRIPTION
The `compression_ratio` function calculates `len(text) / len(zlib.compress(text.encode("utf-8")))`, but `len(text)` returns the length of **string** while `len(zlib.compress(text.encode("utf-8")))` returns the length of **bytes**.
Due to this discrepancy, when recognizing languages with multibyte characters, such as Japanese, compression_ratios are _underestimated_ and more repetitions occur than in English, according to my experience. This PR fixes the issue by calculating text length in bytes.

As far as I experimented, this change made the default compression_ratio value (= 2.4) work better and improved recognition accuracy on my Japanese dataset. For English datasets, ASCII characters consist of a single byte, so the performance change due to this PR is expected to be almost negligible.

NOTE: This PR affects recognition accuracy mainly for languages with multibyte characters, so merging it should be with caution. I confirmed that it worked well on my private Japanese dataset, but performance may be degraded on other datasets.