### PR TITLE
Allows Whisper AI to be uploaded to pypi as a package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ __pycache__/
 thumbs.db
 .DS_Store
 .idea
-
+/build
+/dist

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Whisper
 
+This is an UNOFFICIAL distribution of whisper.ai.
+
 [[Blog]](https://openai.com/blog/whisper)
 [[Paper]](https://cdn.openai.com/papers/whisper.pdf)
 [[Model card]](model-card.md)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import pkg_resources
 from setuptools import setup, find_packages
 
 setup(
-    name="whisper",
+    name="whisper.ai",
     py_modules=["whisper"],
     version="1.0",
     description="Robust Speech Recognition via Large-Scale Weak Supervision",

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,20 @@ import os
 import pkg_resources
 from setuptools import setup, find_packages
 
+# The directory containing this file
+HERE = os.path.dirname(__file__)
+# The text of the README file
+with open(os.path.join(HERE, "README.md"), encoding="utf-8", mode="r") as fd:
+    README = fd.read()
+
+
 setup(
     name="whisper.ai",
     py_modules=["whisper"],
-    version="1.0",
+    version="1.0.0.1",
     description="Robust Speech Recognition via Large-Scale Weak Supervision",
+    long_description=README,
+    long_description_content_type="text/markdown",
     readme="README.md",
     python_requires=">=3.7",
     author="OpenAI",

--- a/upload_pypi.sh
+++ b/upload_pypi.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+set -e
+rm -rf build dist
+echo "Building Source and Wheel (universal) distribution…"
+python setup.py sdist bdist_wheel --universal
+echo "Uploading the package to PyPI via Twine…"
+twine upload dist/* --verbose


### PR DESCRIPTION
This allows WhisperAI to be used as a python package. I've tested this to ensure that it works.

Note that there is already a `whisper` package which is unrelated. I choose `whisper.ai` as the package name. I'm willing to cede this name to openai with no strings attached - just ask.