### PR TITLE
verbose print catch UnicodeEncodeError

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -165,7 +165,10 @@ def transcribe(
             }
         )
         if verbose:
-            print(f"[{format_timestamp(start)} --> {format_timestamp(end)}] {text}")
+            try:
+                print(f"[{format_timestamp(start)} --> {format_timestamp(end)}] {text}")
+            except UnicodeEncodeError:
+                print(f"[{format_timestamp(start)} --> {format_timestamp(end)}] <TEXT ENCODE ERROR>")
 
     # show the progress bar when verbose is False (otherwise the transcribed text will be printed)
     num_frames = mel.shape[-1]


### PR DESCRIPTION
New to python.
Sometimes I have this error in Windows.
This is a work around, maybe set encoding is a better solution, but I dont know if other encoding will cause the output in terminal to be unreadable.

```
Traceback (most recent call last):
  File "C:\Python39\Scripts\whisper-script.py", line 33, in <module>
    sys.exit(load_entry_point('whisper==1.0', 'console_scripts', 'whisper')())
  File "C:\Python39\lib\site-packages\whisper\transcribe.py", line 307, in cli
    result = transcribe(model, audio_path, temperature=temperature, **args)
  File "C:\Python39\lib\site-packages\whisper\transcribe.py", line 207, in transcribe
    add_segment(
  File "C:\Python39\lib\site-packages\whisper\transcribe.py", line 168, in add_segment
    print(f"[{format_timestamp(start)} --> {format_timestamp(end)}] {text}")
UnicodeEncodeError: 'gbk' codec can't encode character '\u266a' in position 33: illegal multibyte sequence
