### PR TITLE
Add `no_speech_threshold` and `logprob_threshold` to DecodingOptions

### DIFF
--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -99,6 +99,10 @@ class DecodingOptions:
     # implementation details
     fp16: bool = True  # use fp16 for most of the calculation
 
+    # silence and failure parameters
+    no_speech_threshold: float = 0.6
+    logprob_threshold: Optional[float] = -1.0
+
 
 @dataclass(frozen=True)
 class DecodingResult:


### PR DESCRIPTION
## Description

To solve the silence issue one has to adjust the  `no_speech_threshold` and `logprob_threshold` values (see [discussion#29](https://github.com/openai/whisper/discussions/29)). At the moment, this isn't as straightforward as one wishes. This PR tries to make setting these options easier.

#### Currently:
```python 
model = whisper.load_model('tiny')
options = whisper.DecodingOptions().__dict__.copy()
options['no_speech_threshold'] = 0.275
options['logprob_threshold'] = None
result = model.transcribe('/path/to/file', **options, verbose=False)
```

#### After this PR
```python
model = whisper.load_model('tiny')
options = whisper.DecodingOptions(language='en', no_speech_threshold=0.275, logprob_threshold=None)
result = model.transcribe('/path/to/file', **options.__dict__, verbose=False)
```

## Implementation
Add  `no_speech_threshold` and `logprob_threshold` to DecodingOptions data class.