### PR TITLE
Add cli for downloading models

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,10 @@ setup(
         )
     ],
     entry_points = {
-        'console_scripts': ['whisper=whisper.transcribe:cli'],
+        'console_scripts': [
+            'whisper=whisper.transcribe:cli',
+            'whisper-download=whisper.download:cli',
+        ],
     },
     include_package_data=True,
     extras_require={'dev': ['pytest']},

--- a/whisper/download.py
+++ b/whisper/download.py
@@ -1,0 +1,21 @@
+import os
+import argparse
+
+
+def cli():
+    from . import _MODELS, _download, available_models
+
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--model", default="small", choices=available_models(), help="name of the Whisper model to use")
+    parser.add_argument("--model_dir", type=str, default=None, help="the path to save model files; uses ~/.cache/whisper by default")
+
+    args = parser.parse_args().__dict__
+
+    download_root = args["model_dir"]
+    if download_root is None:
+        download_root = os.getenv(
+            "XDG_CACHE_HOME", 
+            os.path.join(os.path.expanduser("~"), ".cache", "whisper")
+        )
+
+    _download(_MODELS[args["model"]], download_root, False)


### PR DESCRIPTION
This PR proposes an aditional console script for downloading models. 

```bash
(venv) nezhar@nezhar:~/DEV$ whisper-download --help
usage: whisper-download [-h]
                        [--model {tiny.en,tiny,base.en,base,small.en,small,medium.en,medium,large-v1,large-v2,large}]
                        [--model_dir MODEL_DIR]

options:
  -h, --help            show this help message and exit
  --model {tiny.en,tiny,base.en,base,small.en,small,medium.en,medium,large-v1,large-v2,large}
                        name of the Whisper model to use (default: small)
  --model_dir MODEL_DIR
                        the path to save model files; uses ~/.cache/whisper by
                        default (default: None)
```

Example usage:

```bash
(venv) nezhar@nezhar:~/DEV$ whisper-download --model tiny --model_dir whisper_models
100%|█████████████████████████████████████| 72.1M/72.1M [00:45<00:00, 1.66MiB/s]
(venv) nezhar@nezhar:~/DEV$ ls -la whisper_models/
total 73816
drwxrwxr-x  2 nezhar nezhar     4096 Dez 31 16:53 .
drwxrwxr-x 27 nezhar nezhar     4096 Dez 31 16:53 ..
-rw-rw-r--  1 nezhar nezhar 75572083 Dez 31 16:54 tiny.pt
```