### PR TITLE
*Fix catastrophic timestamp drifting from negative duration via clamping*

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -204,6 +204,9 @@ def transcribe(
                     end_timestamp_position = (
                         sliced_tokens[-1].item() - tokenizer.timestamp_begin
                     )
+                    # clamp end-time to at least be 1 frame after start-time
+                    end_timestamp_position = max(end_timestamp_position, start_timestamp_position + time_precision)
+
                     add_segment(
                         start=timestamp_offset + start_timestamp_position * time_precision,
                         end=timestamp_offset + end_timestamp_position * time_precision,


### PR DESCRIPTION
I was recently transcribing a youtube video of several minutes when I noticed the output transcription of _whisper small.en_ looks something like this:

  [02:01.980 --> 02:04.060]  We are GUYS!
  [02:04.300 --> 02:06.460]  I don’t know, we get it.
  **[02:06.660 --> 01:42.960]**  Still, we really don’t want
  [01:42.960 --> 01:56.300]  And if he’d be course told that you could trap the
  [01:56.300 --> 02:01.000]  big secret in my student, well, dang,
  [02:01.000 --> 02:02.700]  he is friendly about your class too.
  ...

The bolded timestamp actually has a negative duration of ~ 24 seconds. This causes some catastrophic error in later transcriptions since the timestamp offset is incorrect by 24 seconds.

I am thinking best solution here is to clamp the end time to at least be one time precision after start time, and prevent catastrophic of the SEEK point.

