### PR TITLE
Support batch-dimension in log_mel_spectogram

### DIFF
--- a/whisper/audio.py
+++ b/whisper/audio.py
@@ -113,7 +113,7 @@ def log_mel_spectrogram(audio: Union[str, np.ndarray, torch.Tensor], n_mels: int
 
     window = torch.hann_window(N_FFT).to(audio.device)
     stft = torch.stft(audio, N_FFT, HOP_LENGTH, window=window, return_complex=True)
-    magnitudes = stft[:, :-1].abs() ** 2
+    magnitudes = stft[..., :-1].abs() ** 2
 
     filters = mel_filters(audio.device, n_mels)
     mel_spec = filters @ magnitudes


### PR DESCRIPTION
`log_mel_spectrogram` makes the assumption in `stft[:, :-1].abs() ** 2` that the input to this function is one dimensional (sequence of audio samples in 16kHz). 

However, all the tensor operating functions can deal with a leading batch dimensions. PyTorch supports the Ellipsis like NumPy to indicate remaining dimensions. This allows us to directly reference the last dimension, instead of assuming that the `stft` frames end up in the second dimension.

By using the ellipsis symbol on the `stft` tensor we can make `log_mel_spectogram` support batched inputs of shape [batch, samples].