### PR TITLE
print '?' if a letter can't be encoded using the system default encoding

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 import warnings
 from typing import List, Optional, Tuple, Union, TYPE_CHECKING
 
@@ -165,7 +166,10 @@ def transcribe(
             }
         )
         if verbose:
-            print(f"[{format_timestamp(start)} --> {format_timestamp(end)}] {text}")
+            line = f"[{format_timestamp(start)} --> {format_timestamp(end)}] {text}\n"
+            # compared to just `print(line)`, this replaces any character not representable using
+            # the system default encoding with an '?', avoiding UnicodeEncodeError.
+            sys.stderr.buffer.write(line.encode(sys.getdefaultencoding(), errors="replace"))
 
     # show the progress bar when verbose is False (otherwise the transcribed text will be printed)
     num_frames = mel.shape[-1]


### PR DESCRIPTION
Handles issue reported in #670 where `print()` fails when the output text is not encodable in the system default encoding, which may happen when the default encoding is not `utf-8`.