### PR TITLE
Handle XDG_CACHE_HOME properly for download_root

### DIFF
--- a/whisper/__init__.py
+++ b/whisper/__init__.py
@@ -94,9 +94,14 @@ def load_model(name: str, device: Optional[Union[str, torch.device]] = None, dow
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
     if download_root is None:
-        download_root = os.getenv(
-            "XDG_CACHE_HOME", 
-            os.path.join(os.path.expanduser("~"), ".cache", "whisper")
+        download_root = os.path.join(
+            os.getenv(
+                "XDG_CACHE_HOME",
+                os.path.join(
+                    os.path.expanduser("~"), ".cache"
+                )
+            ),
+            "whisper"
         )
 
     if name in _MODELS:


### PR DESCRIPTION
It used to download moduls in `$XDG_CACHE_HOME` rather then `$XDG_CACHE_HOME/whisper` when I use the `$XDG_CACHE_HOME` variable in my system.