### PR TITLE
Reconfigure output to utf-8

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 import warnings
 from typing import Optional, Tuple, Union, TYPE_CHECKING
 
@@ -96,6 +97,9 @@ def transcribe(
             if verbose is not None:
                 print(f"Detected language: {LANGUAGES[decode_options['language']].title()}")
 
+    if verbose:
+       sys.stdout.reconfigure(encoding='utf-8')
+       
     language = decode_options["language"]
     task = decode_options.get("task", "transcribe")
     tokenizer = get_tokenizer(model.is_multilingual, language=language, task=task)


### PR DESCRIPTION
When redirecting output to a file on Windows, stdout encoding turns into ascii and whisper output is utf-8 creating a UnicodeEncodeError.