### PR TITLE
Add per token confidence to each segment.

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -146,7 +146,7 @@ def transcribe(
         initial_prompt_tokens = []
 
     def add_segment(
-        *, start: float, end: float, text_tokens: torch.Tensor, result: DecodingResult
+        *, start: float, end: float, text_tokens: torch.Tensor, tokens_probs: list[list[float]], result: DecodingResult
     ):
         text = tokenizer.decode([token for token in text_tokens if token < tokenizer.eot])
         if len(text.strip()) == 0:  # skip empty text output
@@ -160,6 +160,7 @@ def transcribe(
                 "end": end,
                 "text": text,
                 "tokens": text_tokens.tolist(),
+                "tokens_probs": tokens_probs,
                 "temperature": result.temperature,
                 "avg_logprob": result.avg_logprob,
                 "compression_ratio": result.compression_ratio,
@@ -210,6 +211,7 @@ def transcribe(
                         start=timestamp_offset + start_timestamp_position * time_precision,
                         end=timestamp_offset + end_timestamp_position * time_precision,
                         text_tokens=sliced_tokens[1:-1],
+                        tokens_probs=result.tokens_probs[last_slice + 1:current_slice - 1],
                         result=result,
                     )
                     last_slice = current_slice
@@ -231,6 +233,7 @@ def transcribe(
                     start=timestamp_offset,
                     end=timestamp_offset + duration,
                     text_tokens=tokens,
+                    tokens_probs=result.tokens_probs,
                     result=result,
                 )
 


### PR DESCRIPTION
As it seems to be useful for some user, I implemented a way to obtain the per token confidence of the model.

The `tokens_probs` will be added to the dictionary of each `segment` the same way `tokens` is. Each `tokens_probs` item's position in the list exactly matches each item's position in the `tokens` list. The confidence of each token can easily be retrieved because the positions of the elements in the two lists match.

As it is difficult to produce a general method to append the tokens which represent a word together depending on the language, I solely focused on producing the token level confidence. I am aware that there is work in progress about a word level timestamp which deals with regrouping tokens per word when possible: [word-level timestamps in transcribe() #869](https://github.com/openai/whisper/pull/869) 

More specifically the [split_tokens_on_spaces function](https://github.com/openai/whisper/blob/8eb29c3ef10559910cbee47b1baedefd8388458a/whisper/tokenizer.py#L285).

So we could eventually use this to merge confidences of the tokens when the language used allows us to do so.

I would like to know if I would be necessary to set the tokens_probs results in each segment as optional and if what are the expectation about the structure of the implementation of it.