### PR TITLE
remove auxiliary audio extension

### DIFF
--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -68,6 +68,7 @@ class ResultWriter:
 
     def __call__(self, result: dict, audio_path: str):
         audio_basename = os.path.basename(audio_path)
+        audio_basename = os.path.splitext(audio_basename)[0]
         output_path = os.path.join(self.output_dir, audio_basename + "." + self.extension)
 
         with open(output_path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
Old:
`'./abc.wav' -> './abc.wav.srt'`

New:
`'./abc.wav' -> './abc.srt'`
