### PR TITLE
Squash long words at window and sentence boundaries.

### DIFF
--- a/whisper/timing.py
+++ b/whisper/timing.py
@@ -233,7 +233,7 @@ def find_alignment(
         median_duration = np.median(word_durations)
         max_duration = median_duration * 2
         sentence_end_marks = ".。!！?？"
-        # ensure the first word of a sentence is not longer than twice the median word duration.
+        # ensure words at sentence boundaries are not longer than twice the median word duration.
         for i in range(1, len(start_times)):
             if end_times[i] - start_times[i] > max_duration:
                 if words[i] in sentence_end_marks:
@@ -243,7 +243,7 @@ def find_alignment(
         # ensure the first and second word is not longer than twice the median word duration.
         if len(start_times) > 0 and end_times[0] - start_times[0] > max_duration:
             if len(start_times) > 1 and end_times[1] - start_times[1] > max_duration:
-                boundary = max(end_times[2] / 2, end_times[2] - max_duration)
+                boundary = max(end_times[1] / 2, end_times[1] - max_duration)
                 end_times[0] = start_times[1] = boundary
             start_times[0] = max(0, end_times[0] - max_duration)
 
@@ -336,16 +336,17 @@ def add_word_timestamps(
             word_index += 1
 
         if len(words) > 0:
-            # adjust the segment-level timestamps based on the word-level timestamps
             segment["start"] = words[0]["start"]
-            # hack: prefer the segment-level end timestamp if the last word is too long
+            # hack: prefer the segment-level end timestamp if the last word is too long.
             # a better segmentation algorithm based on VAD should be able to replace this.
             if (
-                segment["end"] > segment["start"]
+                segment["end"] > words[-1]["start"]
                 and segment["end"] + 0.5 < words[-1]["end"]
             ):
+                # adjust the word-level timestamps based on the segment-level timestamps
                 words[-1]["end"] = segment["end"]
             else:
+                # adjust the segment-level timestamps based on the word-level timestamps
                 segment["end"] = words[-1]["end"]
 
         segment["words"] = words

--- a/whisper/timing.py
+++ b/whisper/timing.py
@@ -340,7 +340,10 @@ def add_word_timestamps(
             segment["start"] = words[0]["start"]
             # hack: prefer the segment-level end timestamp if the last word is too long
             # a better segmentation algorithm based on VAD should be able to replace this.
-            if segment["end"] > segment["start"] and segment["end"] + 0.5 < words[-1]["end"]:
+            if (
+                segment["end"] > segment["start"]
+                and segment["end"] + 0.5 < words[-1]["end"]
+            ):
                 words[-1]["end"] = segment["end"]
             else:
                 segment["end"] = words[-1]["end"]

--- a/whisper/timing.py
+++ b/whisper/timing.py
@@ -225,17 +225,26 @@ def find_alignment(
         for i, j in zip(word_boundaries[:-1], word_boundaries[1:])
     ]
 
-    # hack: ensure the first and second word is not longer than twice the median word duration.
+    # hack: truncate long words at the start of a window and the start of a sentence.
     # a better segmentation algorithm based on VAD should be able to replace this.
     word_durations = end_times - start_times
     word_durations = word_durations[word_durations.nonzero()]
     if len(word_durations) > 0:
         median_duration = np.median(word_durations)
         max_duration = median_duration * 2
-        if len(word_durations) >= 2 and word_durations[1] > max_duration:
-            boundary = max(end_times[2] / 2, end_times[2] - max_duration)
-            end_times[0] = start_times[1] = boundary
-        if len(word_durations) >= 1 and end_times[0] - start_times[0] > max_duration:
+        sentence_end_marks = ".。!！?？"
+        # ensure the first word of a sentence is not longer than twice the median word duration.
+        for i in range(1, len(start_times)):
+            if end_times[i] - start_times[i] > max_duration:
+                if words[i] in sentence_end_marks:
+                    end_times[i] = start_times[i] + max_duration
+                elif words[i - 1] in sentence_end_marks:
+                    start_times[i] = end_times[i] - max_duration
+        # ensure the first and second word is not longer than twice the median word duration.
+        if len(start_times) > 0 and end_times[0] - start_times[0] > max_duration:
+            if len(start_times) > 1 and end_times[1] - start_times[1] > max_duration:
+                boundary = max(end_times[2] / 2, end_times[2] - max_duration)
+                end_times[0] = start_times[1] = boundary
             start_times[0] = max(0, end_times[0] - max_duration)
 
     return [
@@ -329,6 +338,11 @@ def add_word_timestamps(
         if len(words) > 0:
             # adjust the segment-level timestamps based on the word-level timestamps
             segment["start"] = words[0]["start"]
-            segment["end"] = words[-1]["end"]
+            # hack: prefer the segment-level end timestamp if the last word is too long
+            # a better segmentation algorithm based on VAD should be able to replace this.
+            if segment["end"] > segment["start"] and segment["end"] + 0.5 < words[-1]["end"]:
+                words[-1]["end"] = segment["end"]
+            else:
+                segment["end"] = words[-1]["end"]
 
         segment["words"] = words


### PR DESCRIPTION
This PR improves the heuristic to squash long words at window/sentence boundaries.

The previous heuristic squashed any of the first two words of a window if they were too long, since long words at the start tend to indicate words being stretched out to cover silence at the start of the window.

This PR makes the following 3 improvements:

1. It adds a heuristic to detect long words at sentence boundaries in the middle of the window, and takes these to be indicative of words being stretched to cover silent gaps between sentences. The long boundary words will be squashed appropriately. This prevents many cases where the first word in a sentence comes in seconds too early.
2. It modifies the original heuristic that squashed any of the first two words if they were long, so that now it won't squash the second word if the first word wasn't also long. This is because the long-ness of a word "mid window" is less significant if it comes after a short word, except at a sentence boundary which is already handled by case 1 above.
3. If token inference doesn't complete the last sentence in a window, that last sentence might be discarded and then timestamp alignment may come up with a super elongated word duration for the last word to cover the span where that last sentence would have been. And since that last word end timestamp determines the start of the next window, a chunk of that last sentence will skipped over. In such cases, we can still get an accurate timestamp for the end of the segment coming from the last timestamp token in the finished sequence. So if the last word of the window is super elongated, and the last timestamp token looks reasonable, we prefer it.

Test example: https://audio2.redcircle.com/episodes/6b196013-8672-43d9-be52-4332b3207d93/stream.mp3

BEFORE

https://user-images.githubusercontent.com/19899190/226097083-c7105150-3b3d-49fb-b29c-e43f0a7eb13a.mp4

AFTER

https://user-images.githubusercontent.com/19899190/226097101-fe8b7495-897f-4600-8f92-969e4d4218b8.mp4

### Example of 1. (detecting a gap between sentences mid-window)

In this example, both segments are within the same window. The audio exhibits a 3 second pause between sentences, but the timestamps elongate the first word of the second sentence ("Along") to cover that silence.

Before:

```srt
49
00:00:28,860 --> 00:00:30,100
and unapologetic<u>.</u>

50
00:00:30,100 --> 00:00:33,660
<u>Along</u> with co-host Matt and various guests of The 69 Whiskey Army, this dynamic group
```

After:

```srt
49
00:00:28,860 --> 00:00:29,620
and unapologetic<u>.</u>

50
00:00:32,900 --> 00:00:33,660
<u>Along</u> with co-host Matt and various guests of The 69 Whiskey Army, this dynamic group
```

### Example of 2. (first 2 words of a window incorrectly classified as long)

In this example, the second segment starts a new window. However, the second word of this window ("unapologetic") is naturally long while the word before it ("and") is short, so it is incorrectly classified by the heuristic. As a result, "and apologetic" gets transported 1.5 seconds into the future after squashing.

Before:

```srt
46
00:00:26,580 --> 00:00:27,180
A show once restrained by rules and boundaries now comes straight to you raw,<u> uncensored</u>

47
00:00:28,580 --> 00:00:29,340
<u>and</u> unapologetic.

48
00:00:29,340 --> 00:00:28,860
and<u> unapologetic</u>.

49
00:00:28,860 --> 00:00:30,100
and unapologetic<u>.</u>

50
00:00:30,100 --> 00:00:33,660
<u>Along</u> with co-host Matt and various guests of The 69 Whiskey Army, this dynamic group

```

After:

```srt
46
00:00:26,580 --> 00:00:27,180
A show once restrained by rules and boundaries now comes straight to you raw,<u> uncensored</u>

47
00:00:27,180 --> 00:00:27,480
<u>and</u> unapologetic.

48
00:00:27,480 --> 00:00:28,860
and<u> unapologetic</u>.

49
00:00:28,860 --> 00:00:29,620
and unapologetic<u>.</u>

50
00:00:32,900 --> 00:00:33,660
<u>Along</u> with co-host Matt and various guests of The 69 Whiskey Army, this dynamic group

```

It's a minor change to the original heuristic but I didn't want to modify it too much since I didn't have the original test cases that may have inspired it. My inclination would have been to get rid of it and just generalise (1) to handle both sentence and window boundaries the same way since I have never seen a case where the first TWO words were both elongated, I've only seen the words immediately touching a boundary become elongated (at least since the introduction of the new word-level timestamps feature).

So I've left this in there for now, and if you had test cases where the first two words were elongated, you might be able to come back to this point.

### Example of 3. (end of window being skipped and last word incorrectly elongated)

In this example, the second segment starts a new window. At the end of the first window, the word "you're" is elongated to almost 4 seconds which masks words "going to need to understand because" from the original audio which we never see transcribed - they are skipped over because the next window starts too late.

Before:

```srt
1244
00:07:47,980 --> 00:07:51,340
and girls, these are all the things your parents didn't want you to understand about, but<u> you're</u>

1245
00:07:54,800 --> 00:07:55,280
<u>okay</u>.
```

After:

```srt
1245
00:07:47,980 --> 00:07:48,360
and girls, these are all the things your parents didn't want you to understand about, but<u> you're</u>

1246
00:07:48,360 --> 00:07:48,520
<u>going</u> to need to understand because it's okay.
```