### PR TITLE
IndexError: arrays used as indices must be of integer type

### DIFF
--- a/whisper/timing.py
+++ b/whisper/timing.py
@@ -214,6 +214,8 @@ def find_alignment(
     text_indices, time_indices = dtw(-matrix)
 
     words, word_tokens = tokenizer.split_to_word_tokens(text_tokens + [tokenizer.eot])
+    if len(word_tokens) <= 1:
+        return []
     word_boundaries = np.pad(np.cumsum([len(t) for t in word_tokens[:-1]]), (1, 0))
 
     jumps = np.pad(np.diff(text_indices), (1, 0), constant_values=1).astype(bool)

--- a/whisper/timing.py
+++ b/whisper/timing.py
@@ -214,9 +214,7 @@ def find_alignment(
     text_indices, time_indices = dtw(-matrix)
 
     words, word_tokens = tokenizer.split_to_word_tokens(text_tokens + [tokenizer.eot])
-    if len(word_tokens) <= 1:
-        return []
-    word_boundaries = np.pad(np.cumsum([len(t) for t in word_tokens[:-1]]), (1, 0))
+    word_boundaries = np.pad(np.cumsum([len(t) for t in word_tokens[:-1]], dtype=int), (1, 0))
 
     jumps = np.pad(np.diff(text_indices), (1, 0), constant_values=1).astype(bool)
     jump_times = time_indices[jumps] / TOKENS_PER_SECOND


### PR DESCRIPTION
Happens on some audio chunks:

 ````
Traceback (most recent call last):
  File whisper/transcribe.py", line 316, in transcribe
    add_word_timestamps(
  File whisper/timing.py", line 323, in add_word_timestamps
    alignment = find_alignment(model, tokenizer, text_tokens, mel, num_frames, **kwargs)
  File whisper/timing.py", line 241, in find_alignment
    start_times = jump_times[word_boundaries[:-1]]
IndexError: arrays used as indices must be of integer (or boolean) type
 ````
