### PR TITLE
Implement max line width and max line count, and make word highlighting optional

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -401,6 +401,9 @@ def cli():
     parser.add_argument("--word_timestamps", type=str2bool, default=False, help="(experimental) extract word-level timestamps and refine the results based on them")
     parser.add_argument("--prepend_punctuations", type=str, default="\"\'“¿([{-", help="if word_timestamps is True, merge these punctuation symbols with the next word")
     parser.add_argument("--append_punctuations", type=str, default="\"\'.。,，!！?？:：”)]}、", help="if word_timestamps is True, merge these punctuation symbols with the previous word")
+    parser.add_argument("--highlight_words", type=str2bool, default=False, help="(requires --word_timestamps True) underline each word as it is spoken in srt and vtt")
+    parser.add_argument("--max_line_width", type=optional_int, default=None, help="(requires --word_timestamps True) the maximum number of characters in a line before breaking the line")
+    parser.add_argument("--max_line_count", type=optional_int, default=None, help="(requires --word_timestamps True) the maximum number of lines in a segment")
     parser.add_argument("--threads", type=optional_int, default=0, help="number of threads used by torch for CPU inference; supercedes MKL_NUM_THREADS/OMP_NUM_THREADS")
     # fmt: on
 
@@ -433,9 +436,17 @@ def cli():
     model = load_model(model_name, device=device, download_root=model_dir)
 
     writer = get_writer(output_format, output_dir)
+    word_options = ["highlight_words", "max_line_count", "max_line_width"]
+    if not args["word_timestamps"]:
+        for option in word_options:
+            if args[option]:
+                parser.error(f"--{option} requires --word_timestamps True")
+    if args["max_line_count"] and not args["max_line_width"]:
+        warnings.warn("--max_line_count has no effect without --max_line_width")
+    writer_args = {arg: args.pop(arg) for arg in word_options}
     for audio_path in args.pop("audio"):
         result = transcribe(model, audio_path, temperature=temperature, **args)
-        writer(result, audio_path)
+        writer(result, audio_path, writer_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This implementation is based on `word_timestamps` and so it requires that option to be turned on. Word highlighting has also been made optional and turned off by default.

Examples:

```bash
# Each subtitle has a maximum of 2 lines wrapped to 47 characters:
whisper --word_timestamps True --max_line_width 47 --max_line_count 2 audio.mp3
# Same with word highlighting:
whisper --word_timestamps True --max_line_width 47 --max_line_count 2 --highlight_words True audio.mp3
# Each subtitle preserves the original Whisper segment but wrapped to 47 character lines:
whisper --word_timestamps True --max_line_width 47 audio.mp3
# Same with word highlighting:
whisper --word_timestamps True --max_line_width 47 --highlight_words True audio.mp3
```
When `--max_line_count` is specified, subtitles will be segmented at the line limit, or when there is a pause in the speech. This overcomes segmentation artifacts that can occur at window boundaries mid sentence.

This segmentation approach works better in conjunction with #1114 because that PR fixes some bugs with timestamp accuracy near segment boundaries where boundary words are stretched to cover pauses, making it harder for the current PR to detect those pauses. In the meantime, the current PR detects pauses by measuring the distance between the start timestamps of successive words rather than between the end timestamp of the previous word and the start timestamp of the current word.