### PR TITLE
workflows/python-publish.yml: bump actions version to fix node warning

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,14 +8,14 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-ecosystem/action-regex-match@v2
       id: regex-match
       with:
         text: ${{ github.event.head_commit.message }}
         regex: '^Release ([^ ]+)'
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.8'
     - name: Install dependencies


### PR DESCRIPTION
## Changes

- Bump the `actions/checkout` version to `v3`.
- Bump the `actions/setup-python` version to `v4`.

This PR fixes the Node 12 deprecation warning displayed under Annotatations in Action runs like [here](https://github.com/openai/whisper/actions/runs/4557552569), as the newer checkout version uses Node 16.