### PR TITLE
Fix: disabling conditionning on previous text is not working as expected

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -308,10 +308,6 @@ def transcribe(
                 )
                 seek += segment_size
 
-            if not condition_on_previous_text or result.temperature > 0.5:
-                # do not feed the prompt tokens if a high temperature was used
-                prompt_reset_since = len(all_tokens)
-
             if word_timestamps:
                 add_word_timestamps(
                     segments=current_segments,
@@ -356,6 +352,10 @@ def transcribe(
             all_tokens.extend(
                 [token for segment in current_segments for token in segment["tokens"]]
             )
+
+            if not condition_on_previous_text or result.temperature > 0.5:
+                # do not feed the prompt tokens if a high temperature was used
+                prompt_reset_since = len(all_tokens)
 
             # update progress bar
             pbar.update(min(content_frames, seek) - previous_seek)


### PR DESCRIPTION
Hello,

prompt_reset_since is set before all_tokens is extended hence does not have the expected effect if I interpret correctly the following description:
https://github.com/openai/whisper/blob/c09a7ae299c4c34c5839a76380ae407e7d785914/whisper/transcribe.py#L81-L84


I also moved the `result.temperature > 0.5 ` condition but I am not sure it should be as it seems to be empirical. Let me know.