### PR TITLE
Add new `job_details.model` key to transcribe return dict

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -37,6 +37,7 @@ def transcribe(
     model: "Whisper",
     audio: Union[str, np.ndarray, torch.Tensor],
     *,
+    model_name: str = "small",
     verbose: Optional[bool] = None,
     temperature: Union[float, Tuple[float, ...]] = (0.0, 0.2, 0.4, 0.6, 0.8, 1.0),
     compression_ratio_threshold: Optional[float] = 2.4,
@@ -360,7 +361,13 @@ def transcribe(
             # update progress bar
             pbar.update(min(content_frames, seek) - previous_seek)
 
+    # Include details about the job that just ran
+    job_details = dict(
+        model=model_name
+    )
+
     return dict(
+        job_details=job_details,
         text=tokenizer.decode(all_tokens[len(initial_prompt_tokens) :]),
         segments=all_segments,
         language=language,
@@ -445,7 +452,7 @@ def cli():
         warnings.warn("--max_line_count has no effect without --max_line_width")
     writer_args = {arg: args.pop(arg) for arg in word_options}
     for audio_path in args.pop("audio"):
-        result = transcribe(model, audio_path, temperature=temperature, **args)
+        result = transcribe(model, audio_path, model_name=model_name, temperature=temperature, **args)
         writer(result, audio_path, writer_args)
 
 


### PR DESCRIPTION
Per discussion https://github.com/openai/whisper/discussions/1112

I've added a new key to the return dictionary from the transcribe def:

```JSON
{
    "job_details": {
        "model": "base"
    },
    "text": " And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country.",
    "segments": [{"id": 0, "seek": 0, "start": 0.0, "end": 11.0, "text": " And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country.", "tokens": [50364, 400, 370, 452, 7177, 6280, 11, 1029, 406, 437, 428, 1941, 393, 360, 337, 291, 11, 1029, 437, 291, 393, 360, 337, 428, 1941, 13, 50914], "temperature": 0.0, "avg_logprob": -0.2968965598515102, "compression_ratio": 1.3544303797468353, "no_speech_prob": 0.04440217837691307}], "language": "en"
}
```

Besides `model`, there may be other parameters passed to whisper that could be useful, hence the nested key instead of a top-level property.