### PR TITLE
Fix numba depreceation notice

### DIFF
--- a/whisper/timing.py
+++ b/whisper/timing.py
@@ -54,7 +54,7 @@ def median_filter(x: torch.Tensor, filter_width: int):
     return result
 
 
-@numba.jit
+@numba.jit(nopython=True)
 def backtrace(trace: np.ndarray):
     i = trace.shape[0] - 1
     j = trace.shape[1] - 1


### PR DESCRIPTION
From numba 0.57 raise a warning if `nopython` is not supplied: https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit