### PR TITLE
Remove triton dependency on musllinux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,10 @@ def read_version(fname="whisper/version.py"):
 
 
 requirements = []
+
 if sys.platform.startswith("linux") and platform.machine() == "x86_64":
-    requirements.append("triton==2.0.0")
+    if platform.libc_ver()[0] == "glibc":
+        requirements.append("triton==2.0.0")
 
 setup(
     name="openai-whisper",


### PR DESCRIPTION
`triton` does not currently ship source distributions or musllinux wheels, but `openai-whisper` has a hard pin of `triton==2.0.0` on all `x86_64` Linux targets, making this requirement impossible to satisfy with PyPI alone.

I recommend at least removing the hard pin when not on glibc, though even better would be making `triton` an optional dependency installed with an extra, if possible. Unfortunately, it's [not currently possible](https://discuss.python.org/t/adding-a-default-extra-require-environment/4898) to have an optional depdendency that defaults to "on".