### PR TITLE
[bugfix] No output when providing a prefix

### DIFF
--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -586,7 +586,7 @@ class DecodingTask:
             if self.sample_len is not None:
                 max_prefix_len = self.n_ctx // 2 - self.sample_len
                 prefix_tokens = prefix_tokens[-max_prefix_len:]
-            if not self.without_timestamps:
+            if not self.options.without_timestamps:
                 tokens = tokens + [self.tokenizer.timestamp_begin]
             tokens = tokens + prefix_tokens
 

--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -586,6 +586,8 @@ class DecodingTask:
             if self.sample_len is not None:
                 max_prefix_len = self.n_ctx // 2 - self.sample_len
                 prefix_tokens = prefix_tokens[-max_prefix_len:]
+            if not self.without_timestamps:
+                tokens = tokens + [self.tokenizer.timestamp_begin]
             tokens = tokens + prefix_tokens
 
         if prompt := self.options.prompt:


### PR DESCRIPTION
There is a bug if timestamps are enabled (`without_timestamps` is defaulted to `False` in `DecodingOptions`), the model will fail to generate new output. This is because the `timestamp_begin` token is expected after the start token in the prefix, and it's not being added back as part of the prefix.

![image](https://github.com/openai/whisper/assets/67124639/0e4f7a48-e6df-4d93-b608-5d986b69f863)

This short PR will fix the issue by adding the `timestamp_begin` token back before the prefix and resolve the following issues raised by other users:

- https://github.com/openai/whisper/discussions/818
- https://github.com/openai/whisper/discussions/1085
