### PR TITLE
make content-length lookup more defensive

### DIFF
--- a/whisper/__init__.py
+++ b/whisper/__init__.py
@@ -66,7 +66,7 @@ def _download(url: str, root: str, in_memory: bool) -> Union[bytes, str]:
 
     with urllib.request.urlopen(url) as source, open(download_target, "wb") as output:
         with tqdm(
-            total=int(source.info().get("Content-Length")),
+            total=int(source.info().get("Content-Length")) if source.info().get("Content-Length") is not None else None,
             ncols=80,
             unit="iB",
             unit_scale=True,


### PR DESCRIPTION
Makes the content-length lookup more defensive. Corporate proxies sometimes don’t provide a content-length header and have transfer-encoding as chunked.