### PR TITLE
Return best text

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -148,6 +148,7 @@ def transcribe(
         temperatures = (
             [temperature] if isinstance(temperature, (int, float)) else temperature
         )
+        decode_result = None
         results = {}
 
         for t in temperatures:
@@ -183,8 +184,11 @@ def transcribe(
                 needs_fallback = False  # silence
             if not needs_fallback:
                 break
+        else:
+            # all failed
+            return max(results.values(), key=lambda r: r.avg_logprob)
 
-        return max(results.values(), key=lambda r: r.avg_logprob)
+        return decode_result
 
     seek = 0
     input_stride = exact_div(

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -148,7 +148,7 @@ def transcribe(
         temperatures = (
             [temperature] if isinstance(temperature, (int, float)) else temperature
         )
-        decode_result = None
+        results = {}
 
         for t in temperatures:
             kwargs = {**decode_options}
@@ -162,6 +162,8 @@ def transcribe(
 
             options = DecodingOptions(**kwargs, temperature=t)
             decode_result = model.decode(segment, options)
+
+            results[t] = decode_result
 
             needs_fallback = False
             if (
@@ -182,7 +184,7 @@ def transcribe(
             if not needs_fallback:
                 break
 
-        return decode_result
+        return max(results.values(), key=lambda r: r.avg_logprob)
 
     seek = 0
     input_stride = exact_div(


### PR DESCRIPTION
Currently, when none of the inference made at different temperatures can satisfy all of the "non-fallback" conditions, the last one is returned (the one with the biggest emperature with default args).

This can lead to weird behaviors, for example:
```{python}
# I want to transcribe this piece of audio
print(model.transcribe(audio)["text"]) # Works fine

# I want to transcribe this piece of audio, and i want it to be very good so I increase the min logprob
print(model.transcribe(audio, logprob_threshold=-0.2)["text"]) # Result is bad because the one inference that is returned is the last one, with the biggest temperature
```

This PR doesn't change the behaviour when one of the inferences satisfy all of the conditions.
When it's not the case, the result that is returned is the one leading to the highest `avg_logprob`
When the avg_logprob condition isn't satisfied and the result is re-computed with a greater temperature, the best option is returned