### PR TITLE
Fix exception when generating the subtitles for an audio with no speech

### DIFF
--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -145,7 +145,7 @@ class SubtitlesWriter(ResultWriter):
             if len(subtitle) > 0:
                 yield subtitle
 
-        if "words" in result["segments"][0]:
+        if len(result["segments"]) > 0 and "words" in result["segments"][0]:
             for subtitle in iterate_subtitles():
                 subtitle_start = self.format_timestamp(subtitle[0]["start"])
                 subtitle_end = self.format_timestamp(subtitle[-1]["end"])


### PR DESCRIPTION
When generating the subtitles for an audio with no speech, an exception is thrown because the code assumes that there will be always a segment at index 0 which is not the case.

```
  File "/...lib/python3.11/site-packages/whisper/transcribe.py", line 453, in cli
    writer(result, audio_path, writer_args)
  File "/...lib/python3.11/site-packages/whisper/utils.py", line 255, in write_all
    writer(result, file, options)
  File "/...lib/python3.11/site-packages/whisper/utils.py", line 85, in __call__
    self.write_result(result, file=f, options=options)
  File "/...lib/python3.11/site-packages/whisper/utils.py", line 195, in write_result
    for start, end, text in self.iterate_result(result, options):
  File "/...lib/python3.11/site-packages/whisper/utils.py", line 148, in iterate_result
    if "words" in result["segments"][0]:
                  ~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range

```