### PR TITLE
Create Etheria text

### DIFF
--- a/Etheria text
+++ b/Etheria text
@@ -1,0 +1,9 @@
+In a parallel realm known as Etheria, the fundamental forces of energy and magic intertwine with the human essence. Within Etheria, individuals possess dormant Chakras, powerful energy centers that hold immense magical potential. However, these Chakras are sealed within ancient scrolls, safeguarded by a mystical order known as the Keepers of Balance.
+
+Centuries ago, the Keepers discovered that the uncontrolled release of Chakra energy led to chaos and imbalance, threatening the stability of Etheria. To prevent catastrophe, they devised a system to seal the Chakras within scrolls, ensuring that individuals could only access their powers in a controlled manner.
+
+Each Chakra scroll corresponds to one of the seven energy centers: Root, Sacral, Solar Plexus, Heart, Throat, Third Eye, and Crown. These scrolls, carefully crafted from enchanted materials, are entrusted to worthy individuals who demonstrate the potential to harness the Chakra's power responsibly.
+
+To activate a Chakra scroll, an individual must undergo a sacred ritual overseen by the Keepers. During the ceremony, the person assigns an elemental affinity to the scroll, aligning it with one of the five primary elements—Earth, Water, Fire, Air, or Ether. This elemental affinity serves as the key to unlocking the Chakra's magic.
+
+Once the elemental affinity is chosen, the scroll resonates with the individual's energy, and the Chakra within awakens, granting access to a specific set of magical abilities related to the assigned element. For example, someone with a Fire-affinity Solar Plexus Chakra scroll might gain powers of fire manipulation, enhanced willpower, and heightened energy.


### PR DESCRIPTION
In a parallel realm known as Etheria, the fundamental forces of energy and magic intertwine with the human essence. Within Etheria, individuals possess dormant Chakras, powerful energy centers that hold immense magical potential. However, these Chakras are sealed within ancient scrolls, safeguarded by a mystical order known as the Keepers of Balance.

Centuries ago, the Keepers discovered that the uncontrolled release of Chakra energy led to chaos and imbalance, threatening the stability of Etheria. To prevent catastrophe, they devised a system to seal the Chakras within scrolls, ensuring that individuals could only access their powers in a controlled manner.

Each Chakra scroll corresponds to one of the seven energy centers: Root, Sacral, Solar Plexus, Heart, Throat, Third Eye, and Crown. These scrolls, carefully crafted from enchanted materials, are entrusted to worthy individuals who demonstrate the potential to harness the Chakra's power responsibly.

To activate a Chakra scroll, an individual must undergo a sacred ritual overseen by the Keepers. During the ceremony, the person assigns an elemental affinity to the scroll, aligning it with one of the five primary elements—Earth, Water, Fire, Air, or Ether. This elemental affinity serves as the key to unlocking the Chakra's magic.

Once the elemental affinity is chosen, the scroll resonates with the individual's energy, and the Chakra within awakens, granting access to a specific set of magical abilities related to the assigned element. For example, someone with a Fire-affinity Solar Plexus Chakra scroll might gain powers of fire manipulation, enhanced willpower, and heightened energy.