### PR TITLE
Add support for AMD GPU (ROCm Platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ To update the package to the latest version of this repository, please run:
 
     pip install --upgrade --no-deps --force-reinstall git+https://github.com/openai/whisper.git
 
+For AMD GPU (ROCm Platform), you need install pytorch for ROCm at the first, then install whisper from source:
+    WHISPER_ROCM=1 pip install --no-build-isolation  git+https://github.com/openai/whisper.git
+
+To update the package to the latest version of this repository for AMD GPU (ROCm Platform), please run:
+
+    WHISPER_ROCM=1 pip install --upgrade --no-deps --force-reinstall git+https://github.com/openai/whisper.git
+
+
 It also requires the command-line tool [`ffmpeg`](https://ffmpeg.org/) to be installed on your system, which is available from most package managers:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ To update the package to the latest version of this repository, please run:
     pip install --upgrade --no-deps --force-reinstall git+https://github.com/openai/whisper.git
 
 For AMD GPU (ROCm Platform), you need install pytorch for ROCm at the first, then install whisper from source:
+
     WHISPER_ROCM=1 pip install --no-build-isolation  git+https://github.com/openai/whisper.git
 
 To update the package to the latest version of this repository for AMD GPU (ROCm Platform), please run:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To update the package to the latest version of this repository, please run:
 
     pip install --upgrade --no-deps --force-reinstall git+https://github.com/openai/whisper.git
 
-For AMD GPU (ROCm Platform), you need install pytorch for ROCm at the first, then install whisper from source:
+For AMD GPU (ROCm Platform), you need to install pytorch for ROCm at the first, then install whisper from source:
 
     WHISPER_ROCM=1 pip install --no-build-isolation  git+https://github.com/openai/whisper.git
 

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,12 @@ def read_version(fname="whisper/version.py"):
 
 
 requirements = []
+whisper_rocm = os.getenv('WHISPER_ROCM',default='0')
 if sys.platform.startswith("linux") and platform.machine() == "x86_64":
-    requirements.append("triton==2.0.0")
+    if whisper_rocm == "1" :
+        requirements.append("pytorch_triton_rocm==2.0.2")
+    else :
+        requirements.append("triton==2.0.0")
 
 setup(
     name="openai-whisper",


### PR DESCRIPTION
PyPI name of openAI Triton for ROCm Platform is pytorch-triton-rocm, so that modify setup.py to install correct Triton package for ROCm platform. Also modify README.md to add instruction to install on ROCm Platform. Tested on ROCm Platform with AMD GPUs.