### PR TITLE
Avoid rearranging all caches

### DIFF
--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -145,7 +145,7 @@ class PyTorchInference(Inference):
         self.initial_token_length = initial_token_length
         self.kv_cache = {}
         self.hooks = []
-        
+
         key_modules = [block.attn.key for block in self.model.decoder.blocks]
         value_modules = [block.attn.value for block in self.model.decoder.blocks]
         self.kv_modules = key_modules + value_modules

--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -673,7 +673,6 @@ class DecodingTask:
         return languages, lang_probs
 
     def _main_loop(self, audio_features: Tensor, tokens: Tensor):
-        assert audio_features.shape[0] == tokens.shape[0]
         n_batch = tokens.shape[0]
         sum_logprobs: Tensor = torch.zeros(n_batch, device=audio_features.device)
         no_speech_probs = [np.nan] * n_batch
@@ -726,8 +725,7 @@ class DecodingTask:
                 )
             ]
 
-        # repeat the audio & text tensors by the group size, for beam search or best-of-n sampling
-        audio_features = audio_features.repeat_interleave(self.n_group, dim=0)
+        # repeat text tensors by the group size, for beam search or best-of-n sampling
         tokens = tokens.repeat_interleave(self.n_group, dim=0).to(audio_features.device)
 
         # call the main sampling loop


### PR DESCRIPTION
Since kv_caches from cross attention block is the same for each beam, we can avoid rearranging or calculating it for multiple times. 
I saw about 20% speed up of large model with beam_size = 5 on cpu backend.