### PR TITLE
fix-space-issue

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -27,6 +27,7 @@ from .utils import (
     optional_float,
     optional_int,
     str2bool,
+    remove_leading_spaces,
 )
 
 if TYPE_CHECKING:
@@ -368,11 +369,16 @@ def transcribe(
             # update progress bar
             pbar.update(min(content_frames, seek) - previous_seek)
 
-    return dict(
-        text=tokenizer.decode(all_tokens[len(initial_prompt_tokens) :]),
-        segments=all_segments,
-        language=language,
-    )
+        result = dict(
+            text=tokenizer.decode(all_tokens[len(initial_prompt_tokens) :]),
+            segments=all_segments,
+            language=language,
+        )
+
+        if decode_options["language"] == "ko":
+            result = remove_leading_spaces(result)
+
+    return result
 
 
 def cli():

--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -256,3 +256,21 @@ def get_writer(
         return write_all
 
     return writers[output_format](output_dir)
+
+
+def remove_leading_spaces(
+        result: dict
+) -> dict:
+    """
+    Removes unwanted leading spaces from the main 'text' field and each 'text' field in the 'segments' list.
+    This function is currently applied specifically to some languages to correct formatting issues.
+    Currently monitored language: Korean
+    """
+    if result['text'].startswith(' '):
+        result['text'] = result['text'][1:]
+
+    for segment in result['segments']:
+        if segment['text'].startswith(' '):
+            segment['text'] = segment['text'][1:]
+
+    return result


### PR DESCRIPTION
Hi, I really appreciate your work.

I couldn't identify the exact reason why this happens, but there are some unwanted spaces before the text in each segment when I use `transcribe()` in some languages. 

For example, when I transcribe Korean, the result looks like this:

```
{
  "text": " 안녕하세요 반갑습니다. 각 세그먼트 앞에 띄어쓰기가 존재하나요?",
  "segments": [
    {
      "id": 0,
      "seek": 0,
      "start": 0.0,
      "end": 2.0,
      "text": " 안녕하세요 반갑습니다.",
      "tokens": [19289, 16396, 27358, 3115, 13],
      "temperature": 0.0,
      "avg_logprob": -0.4206415044850317,
      "compression_ratio": 0.9081632653061225,
      "no_speech_prob": 0.020465657114982605
    },
    {
      "id": 1,
      "seek": 200,
      "start": 2.0,
      "end": 30.0,
      "text": " 각 세그먼트 앞에 띄어쓰기가 존재하나요?",
      "tokens": [50364, 28378, 11605, 10557, 48150, 8857, 42004, 531, 251, 226, 2782, 241, 108, 16056, 22116, 28364, 105, 8037, 26057, 30, 51764],
      "temperature": 0.0,
      "avg_logprob": -0.2779767730019309,
      "compression_ratio": 0.835820895522388,
      "no_speech_prob": 0.0011142527218908072
    }
  ],
  "language": "ko"
}
``` 
I've seen this in several Korean audio files, and many people have reported it as well. 
Every Korean audio file so far has shown this space. 

The only language in which I've observed this space is Korean. And I couldn't identify why this happens; it might be a problem with the tokenizer?

To address this issue, I created a function that removes the leading space if it exists in the Korean text. I added this function to `utils.py` and applied it to the `transcribe()` method to clean up the output.

I've tested these changes with various Korean audio files and confirmed that the unwanted spaces are removed. 
