### PR TITLE
handling transcribe exceptions.

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -453,8 +453,11 @@ def cli():
         warnings.warn("--max_line_count has no effect without --max_line_width")
     writer_args = {arg: args.pop(arg) for arg in word_options}
     for audio_path in args.pop("audio"):
-        result = transcribe(model, audio_path, temperature=temperature, **args)
-        writer(result, audio_path, writer_args)
+        try:
+            result = transcribe(model, audio_path, temperature=temperature, **args)
+            writer(result, audio_path, writer_args)
+        except:
+            print("Error transcribing. File skipped: " + audio_path)
 
 
 if __name__ == "__main__":

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import traceback
 import warnings
 from typing import TYPE_CHECKING, Optional, Tuple, Union
 
@@ -456,8 +457,9 @@ def cli():
         try:
             result = transcribe(model, audio_path, temperature=temperature, **args)
             writer(result, audio_path, writer_args)
-        except:
-            print("Error transcribing. File skipped: " + audio_path)
+        except Exception as e:
+            traceback.print_exc()
+            print(f"Skipping {audio_path} due to {type(e).__name__}: {str(e)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When processing multiple files through CLI, whisper dies on the first transcribe failure.

This change allows the processing to keep going and displays which files failed processing.