### PR TITLE
docs: Disambiguation of the term "relative speed" in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ There are five model sizes, four with English-only versions, offering speed and 
 | medium |   769 M    |    `medium.en`     |      `medium`      |     ~5 GB     |      ~2x       |
 | large  |   1550 M   |        N/A         |      `large`       |    ~10 GB     |       1x       |
 
+Note that "relative speed" here refers to the speed of transcription of each model relative to each other, rather than relative to the duration of the sample to transcribe. Speed of transcription will vary based on the available hardware resources.
+
 The `.en` models for English-only applications tend to perform better, especially for the `tiny.en` and `base.en` models. We observed that the difference becomes less significant for the `small.en` and `medium.en` models.
 
 Whisper's performance varies widely depending on the language. The figure below shows a WER (Word Error Rate) breakdown by languages of the Fleurs dataset using the `large-v2` model (The smaller the numbers, the better the performance). Additional WER scores corresponding to the other models and datasets can be found in Appendix D.1, D.2, and D.4. Meanwhile, more BLEU (Bilingual Evaluation Understudy) scores can be found in Appendix D.3. Both are found in [the paper](https://arxiv.org/abs/2212.04356). 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ pip install setuptools-rust
 
 ## Available models and languages
 
-There are five model sizes, four with English-only versions, offering speed and accuracy tradeoffs. Below are the names of the available models and their approximate memory requirements and relative speed. 
-
+There are five model sizes, four with English-only versions, offering speed and accuracy tradeoffs. Below are the names of the available models and their approximate memory requirements and inference speed relative to the large model; actual speed may vary depending on many factors including the available hardware.
 
 |  Size  | Parameters | English-only model | Multilingual model | Required VRAM | Relative speed |
 |:------:|:----------:|:------------------:|:------------------:|:-------------:|:--------------:|
@@ -67,8 +66,6 @@ There are five model sizes, four with English-only versions, offering speed and 
 | small  |   244 M    |     `small.en`     |      `small`       |     ~2 GB     |      ~6x       |
 | medium |   769 M    |    `medium.en`     |      `medium`      |     ~5 GB     |      ~2x       |
 | large  |   1550 M   |        N/A         |      `large`       |    ~10 GB     |       1x       |
-
-Note that "relative speed" here refers to the speed of transcription of each model relative to each other, rather than relative to the duration of the sample to transcribe. Speed of transcription will vary based on the available hardware resources.
 
 The `.en` models for English-only applications tend to perform better, especially for the `tiny.en` and `base.en` models. We observed that the difference becomes less significant for the `small.en` and `medium.en` models.
 


### PR DESCRIPTION
## Description

As per [discussion 1747](https://github.com/openai/whisper/discussions/1747), this is a very simple PR to disambiguate the term "relative speed".
While I know the edit may introduce something that seem obvious to many users, I don't think the extra precision can hurt 😄