### PR TITLE
Relax triton requirements for compatibility with pytorch 2.1 and newer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read_version(fname="whisper/version.py"):
 
 requirements = []
 if sys.platform.startswith("linux") and platform.machine() == "x86_64":
-    requirements.append("triton==2.0.0")
+    requirements.append("triton>=2.0.0,<3")
 
 setup(
     name="openai-whisper",


### PR DESCRIPTION
PyPI package of PyTorch 2.1 uses triton==2.1.0, which makes it incompatible with whisper due to overly strict requirement triton==2.0.0.