### PR TITLE
Making a small type change

### DIFF
--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -169,7 +169,7 @@ class PyTorchInference(Inference):
         self.kv_cache = {}
         self.hooks = []
 
-    def rearrange_kv_cache(self, source_indices):
+    def rearrange_kv_cache(self, source_indices : List[int]):
         if source_indices != list(range(len(source_indices))):
             for module in self.kv_modules:
                 # update the key/value cache to contain the selected sequences


### PR DESCRIPTION
Hi, I noticed a lack of typing for the `source_indices` argument for the method, `rearrange_kv_cache` in `PyTorchInference` and added it. Have a nice day!