### PR TITLE
Skip silence around hallucinations

### DIFF
--- a/whisper/timing.py
+++ b/whisper/timing.py
@@ -299,6 +299,7 @@ def add_word_timestamps(
     word_durations = np.array([t.end - t.start for t in alignment])
     word_durations = word_durations[word_durations.nonzero()]
     median_duration = np.median(word_durations) if len(word_durations) > 0 else 0.0
+    median_duration = min(0.7, float(median_duration))
     max_duration = median_duration * 2
 
     # hack: truncate long words at sentence boundaries.

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import traceback
 import warnings
-from typing import TYPE_CHECKING, Optional, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -49,7 +49,7 @@ def transcribe(
     word_timestamps: bool = False,
     prepend_punctuations: str = "\"'“¿([{-",
     append_punctuations: str = "\"'.。,，!！?？:：”)]}、",
-    clip_timestamps: Union[str, list[float]] = "0",
+    clip_timestamps: Union[str, List[float]] = "0",
     hallucination_silence_threshold: Optional[float] = None,
     **decode_options,
 ):
@@ -105,7 +105,7 @@ def transcribe(
     decode_options: dict
         Keyword arguments to construct `DecodingOptions` instances
 
-    clip_timestamps: Union[str, list[float]]
+    clip_timestamps: Union[str, List[float]]
         Comma-separated list start,end,start,end,... timestamps (in seconds) of clips to process.
         The last end timestamp defaults to the end of the file.
 
@@ -163,12 +163,12 @@ def transcribe(
         clip_timestamps = [
             float(ts) for ts in (clip_timestamps.split(",") if clip_timestamps else [])
         ]
-    seek_points: list[int] = [round(ts * FRAMES_PER_SECOND) for ts in clip_timestamps]
+    seek_points: List[int] = [round(ts * FRAMES_PER_SECOND) for ts in clip_timestamps]
     if len(seek_points) == 0:
         seek_points.append(0)
     if len(seek_points) % 2 == 1:
         seek_points.append(content_frames)
-    seek_clips: list[Tuple[int, int]] = list(zip(seek_points[::2], seek_points[1::2]))
+    seek_clips: List[Tuple[int, int]] = list(zip(seek_points[::2], seek_points[1::2]))
 
     punctuation = "\"'“¿([{-\"'.。,，!！?？:：”)]}、"
 
@@ -317,7 +317,7 @@ def transcribe(
                 score = sum(word_anomaly_score(w) for w in words)
                 return score >= 3 or score + 0.01 >= len(words)
 
-            def next_words_segment(segments: list[dict]) -> Optional[dict]:
+            def next_words_segment(segments: List[dict]) -> Optional[dict]:
                 return next((s for s in segments if s["words"]), None)
 
             timestamp_tokens: torch.Tensor = tokens.ge(tokenizer.timestamp_begin)

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -23,6 +23,7 @@ from .tokenizer import LANGUAGES, TO_LANGUAGE_CODE, get_tokenizer
 from .utils import (
     exact_div,
     format_timestamp,
+    get_end,
     get_writer,
     make_safe,
     optional_float,
@@ -48,6 +49,7 @@ def transcribe(
     word_timestamps: bool = False,
     prepend_punctuations: str = "\"'“¿([{-",
     append_punctuations: str = "\"'.。,，!！?？:：”)]}、",
+    clip_timestamps: Union[str, list[float]] = "0",
     **decode_options,
 ):
     """
@@ -102,6 +104,10 @@ def transcribe(
     decode_options: dict
         Keyword arguments to construct `DecodingOptions` instances
 
+    clip_timestamps: Union[str, list[float]]
+        Comma-separated list start,end,start,end,... timestamps (in seconds) of clips to process.
+        The last end timestamp defaults to the end of the file.
+
     Returns
     -------
     A dictionary containing the resulting text ("text") and segment-level details ("segments"), and
@@ -147,6 +153,17 @@ def transcribe(
         task=task,
     )
 
+    if isinstance(clip_timestamps, str):
+        clip_timestamps = [
+            float(ts) for ts in (clip_timestamps.split(",") if clip_timestamps else [])
+        ]
+    seek_points: list[int] = [round(ts * FRAMES_PER_SECOND) for ts in clip_timestamps]
+    if len(seek_points) == 0:
+        seek_points.append(0)
+    if len(seek_points) % 2 == 1:
+        seek_points.append(content_frames)
+    seek_clips: list[Tuple[int, int]] = list(zip(seek_points[::2], seek_points[1::2]))
+
     if word_timestamps and task == "translate":
         warnings.warn("Word-level timestamps on translations may not be reliable.")
 
@@ -190,7 +207,8 @@ def transcribe(
 
         return decode_result
 
-    seek = 0
+    clip_idx = 0
+    seek = seek_clips[clip_idx][0]
     input_stride = exact_div(
         N_FRAMES, model.dims.n_audio_ctx
     )  # mel frames per output token: 2
@@ -229,10 +247,22 @@ def transcribe(
         total=content_frames, unit="frames", disable=verbose is not False
     ) as pbar:
         last_speech_timestamp = 0.0
-        while seek < content_frames:
+        # NOTE: This loop is obscurely flattened to make the diff readable.
+        # A later commit should turn this into a simpler nested loop.
+        # for seek_clip_start, seek_clip_end in seek_clips:
+        #     while seek < seek_clip_end
+        while clip_idx < len(seek_clips):
+            seek_clip_start, seek_clip_end = seek_clips[clip_idx]
+            if seek < seek_clip_start:
+                seek = seek_clip_start
+            if seek >= seek_clip_end:
+                clip_idx += 1
+                if clip_idx < len(seek_clips):
+                    seek = seek_clips[clip_idx][0]
+                continue
             time_offset = float(seek * HOP_LENGTH / SAMPLE_RATE)
-            mel_segment = mel[:, seek : seek + N_FRAMES]
-            segment_size = min(N_FRAMES, content_frames - seek)
+            segment_size = min(N_FRAMES, content_frames - seek, seek_clip_end - seek)
+            mel_segment = mel[:, seek : seek + segment_size]
             segment_duration = segment_size * HOP_LENGTH / SAMPLE_RATE
             mel_segment = pad_or_trim(mel_segment, N_FRAMES).to(model.device).to(dtype)
 
@@ -330,17 +360,15 @@ def transcribe(
                     append_punctuations=append_punctuations,
                     last_speech_timestamp=last_speech_timestamp,
                 )
-                word_end_timestamps = [
-                    w["end"] for s in current_segments for w in s["words"]
-                ]
-                if len(word_end_timestamps) > 0:
-                    last_speech_timestamp = word_end_timestamps[-1]
-                if not single_timestamp_ending and len(word_end_timestamps) > 0:
-                    seek_shift = round(
-                        (word_end_timestamps[-1] - time_offset) * FRAMES_PER_SECOND
-                    )
-                    if seek_shift > 0:
-                        seek = previous_seek + seek_shift
+
+                if not single_timestamp_ending:
+                    last_word_end = get_end(current_segments)
+                    if last_word_end is not None and last_word_end > time_offset:
+                        seek = round(last_word_end * FRAMES_PER_SECOND)
+
+                last_word_end = get_end(current_segments)
+                if last_word_end is not None:
+                    last_speech_timestamp = last_word_end
 
             if verbose:
                 for segment in current_segments:
@@ -427,6 +455,7 @@ def cli():
     parser.add_argument("--max_line_count", type=optional_int, default=None, help="(requires --word_timestamps True) the maximum number of lines in a segment")
     parser.add_argument("--max_words_per_line", type=optional_int, default=None, help="(requires --word_timestamps True, no effect with --max_line_width) the maximum number of words in a segment")
     parser.add_argument("--threads", type=optional_int, default=0, help="number of threads used by torch for CPU inference; supercedes MKL_NUM_THREADS/OMP_NUM_THREADS")
+    parser.add_argument("--clip_timestamps", type=str, default="0", help="comma-separated list start,end,start,end,... timestamps (in seconds) of clips to process, where the last end timestamp defaults to the end of the file")
     # fmt: on
 
     args = parser.parse_args().__dict__

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -50,6 +50,7 @@ def transcribe(
     prepend_punctuations: str = "\"'“¿([{-",
     append_punctuations: str = "\"'.。,，!！?？:：”)]}、",
     clip_timestamps: Union[str, list[float]] = "0",
+    hallucination_silence_threshold: Optional[float] = None,
     **decode_options,
 ):
     """
@@ -108,6 +109,10 @@ def transcribe(
         Comma-separated list start,end,start,end,... timestamps (in seconds) of clips to process.
         The last end timestamp defaults to the end of the file.
 
+    hallucination_silence_threshold: Optional[float]
+        When word_timestamps is True, skip silent periods longer than this threshold (in seconds)
+        when a possible hallucination is detected
+
     Returns
     -------
     A dictionary containing the resulting text ("text") and segment-level details ("segments"), and
@@ -127,6 +132,7 @@ def transcribe(
     # Pad 30-seconds of silence to the input audio, for slicing
     mel = log_mel_spectrogram(audio, model.dims.n_mels, padding=N_SAMPLES)
     content_frames = mel.shape[-1] - N_FRAMES
+    content_duration = float(content_frames * HOP_LENGTH / SAMPLE_RATE)
 
     if decode_options.get("language", None) is None:
         if not model.is_multilingual:
@@ -163,6 +169,8 @@ def transcribe(
     if len(seek_points) % 2 == 1:
         seek_points.append(content_frames)
     seek_clips: list[Tuple[int, int]] = list(zip(seek_points[::2], seek_points[1::2]))
+
+    punctuation = "\"'“¿([{-\"'.。,，!！?？:：”)]}、"
 
     if word_timestamps and task == "translate":
         warnings.warn("Word-level timestamps on translations may not be reliable.")
@@ -261,6 +269,7 @@ def transcribe(
                     seek = seek_clips[clip_idx][0]
                 continue
             time_offset = float(seek * HOP_LENGTH / SAMPLE_RATE)
+            window_end_time = float((seek + N_FRAMES) * HOP_LENGTH / SAMPLE_RATE)
             segment_size = min(N_FRAMES, content_frames - seek, seek_clip_end - seek)
             mel_segment = mel[:, seek : seek + segment_size]
             segment_duration = segment_size * HOP_LENGTH / SAMPLE_RATE
@@ -286,6 +295,30 @@ def transcribe(
 
             previous_seek = seek
             current_segments = []
+
+            # anomalous words are very long/short/improbable
+            def word_anomaly_score(word: dict) -> float:
+                probability = word.get("probability", 0.0)
+                duration = word["end"] - word["start"]
+                score = 0.0
+                if probability < 0.15:
+                    score += 1.0
+                if duration < 0.133:
+                    score += (0.133 - duration) * 15
+                if duration > 2.0:
+                    score += duration - 2.0
+                return score
+
+            def is_segment_anomaly(segment: Optional[dict]) -> bool:
+                if segment is None or not segment["words"]:
+                    return False
+                words = [w for w in segment["words"] if w["word"] not in punctuation]
+                words = words[:8]
+                score = sum(word_anomaly_score(w) for w in words)
+                return score >= 3 or score + 0.01 >= len(words)
+
+            def next_words_segment(segments: list[dict]) -> Optional[dict]:
+                return next((s for s in segments if s["words"]), None)
 
             timestamp_tokens: torch.Tensor = tokens.ge(tokenizer.timestamp_begin)
             single_timestamp_ending = timestamp_tokens[-2:].tolist() == [False, True]
@@ -365,6 +398,62 @@ def transcribe(
                     last_word_end = get_end(current_segments)
                     if last_word_end is not None and last_word_end > time_offset:
                         seek = round(last_word_end * FRAMES_PER_SECOND)
+
+                # skip silence before possible hallucinations
+                if hallucination_silence_threshold is not None:
+                    threshold = hallucination_silence_threshold
+                    if not single_timestamp_ending:
+                        last_word_end = get_end(current_segments)
+                        if last_word_end is not None and last_word_end > time_offset:
+                            remaining_duration = window_end_time - last_word_end
+                            if remaining_duration > threshold:
+                                seek = round(last_word_end * FRAMES_PER_SECOND)
+                            else:
+                                seek = previous_seek + segment_size
+
+                    # if first segment might be a hallucination, skip leading silence
+                    first_segment = next_words_segment(current_segments)
+                    if first_segment is not None and is_segment_anomaly(first_segment):
+                        gap = first_segment["start"] - time_offset
+                        if gap > threshold:
+                            seek = previous_seek + round(gap * FRAMES_PER_SECOND)
+                            continue
+
+                    # skip silence before any possible hallucination that is surrounded
+                    # by silence or more hallucinations
+                    hal_last_end = last_speech_timestamp
+                    for si in range(len(current_segments)):
+                        segment = current_segments[si]
+                        if not segment["words"]:
+                            continue
+                        if is_segment_anomaly(segment):
+                            next_segment = next_words_segment(
+                                current_segments[si + 1 :]
+                            )
+                            if next_segment is not None:
+                                hal_next_start = next_segment["words"][0]["start"]
+                            else:
+                                hal_next_start = time_offset + segment_duration
+                            silence_before = (
+                                segment["start"] - hal_last_end > threshold
+                                or segment["start"] < threshold
+                                or segment["start"] - time_offset < 2.0
+                            )
+                            silence_after = (
+                                hal_next_start - segment["end"] > threshold
+                                or is_segment_anomaly(next_segment)
+                                or window_end_time - segment["end"] < 2.0
+                            )
+                            if silence_before and silence_after:
+                                seek = round(
+                                    max(time_offset + 1, segment["start"])
+                                    * FRAMES_PER_SECOND
+                                )
+                                if content_duration - segment["end"] < threshold:
+                                    seek = content_frames
+                                current_segments[si:] = []
+                                break
+                        hal_last_end = segment["end"]
 
                 last_word_end = get_end(current_segments)
                 if last_word_end is not None:
@@ -456,6 +545,7 @@ def cli():
     parser.add_argument("--max_words_per_line", type=optional_int, default=None, help="(requires --word_timestamps True, no effect with --max_line_width) the maximum number of words in a segment")
     parser.add_argument("--threads", type=optional_int, default=0, help="number of threads used by torch for CPU inference; supercedes MKL_NUM_THREADS/OMP_NUM_THREADS")
     parser.add_argument("--clip_timestamps", type=str, default="0", help="comma-separated list start,end,start,end,... timestamps (in seconds) of clips to process, where the last end timestamp defaults to the end of the file")
+    parser.add_argument("--hallucination_silence_threshold", type=optional_float, help="(requires --word_timestamps True) skip silent periods longer than this threshold (in seconds) when a possible hallucination is detected")
     # fmt: on
 
     args = parser.parse_args().__dict__

--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 import zlib
-from typing import Callable, Optional, TextIO
+from typing import Callable, List, Optional, TextIO
 
 system_encoding = sys.getdefaultencoding()
 
@@ -68,14 +68,14 @@ def format_timestamp(
     )
 
 
-def get_start(segments: list[dict]) -> Optional[float]:
+def get_start(segments: List[dict]) -> Optional[float]:
     return next(
         (w["start"] for s in segments for w in s["words"]),
         segments[0]["start"] if segments else None,
     )
 
 
-def get_end(segments: list[dict]) -> Optional[float]:
+def get_end(segments: List[dict]) -> Optional[float]:
     return next(
         (w["end"] for s in reversed(segments) for w in reversed(s["words"])),
         segments[-1]["end"] if segments else None,
@@ -143,7 +143,7 @@ class SubtitlesWriter(ResultWriter):
             line_len = 0
             line_count = 1
             # the next subtitle to yield (a list of word timings with whitespace)
-            subtitle: list[dict] = []
+            subtitle: List[dict] = []
             last: float = get_start(result["segments"]) or 0.0
             for segment in result["segments"]:
                 chunk_index = 0

--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -68,6 +68,20 @@ def format_timestamp(
     )
 
 
+def get_start(segments: list[dict]) -> Optional[float]:
+    return next(
+        (w["start"] for s in segments for w in s["words"]),
+        segments[0]["start"] if segments else None,
+    )
+
+
+def get_end(segments: list[dict]) -> Optional[float]:
+    return next(
+        (w["end"] for s in reversed(segments) for w in reversed(s["words"])),
+        segments[-1]["end"] if segments else None,
+    )
+
+
 class ResultWriter:
     extension: str
 
@@ -130,7 +144,7 @@ class SubtitlesWriter(ResultWriter):
             line_count = 1
             # the next subtitle to yield (a list of word timings with whitespace)
             subtitle: list[dict] = []
-            last = result["segments"][0]["words"][0]["start"]
+            last: float = get_start(result["segments"]) or 0.0
             for segment in result["segments"]:
                 chunk_index = 0
                 words_count = max_words_per_line


### PR DESCRIPTION
This PR introduces a heuristic that determines if a segment is probably a hallucination. If that "probable" hallucination occurs after a period of silence (specified by `--hallucination_silence_threshold` in seconds), then we seek past the silence and reprocess from that point. Eliminating the silence before a hallucination improves the likelihood of getting a correct inference, but since this also requires extra processing time, we only do this when a probable hallucination is detected.

The heuristic itself is based on the observation that words in a hallucination are often either extremely long, extremely short, or have an extremely low probability. The probability of later words may be less reliable, so we take the first 8 words of a segment only, and look for a certain threshold of anomalies within that.

Below are some successive test runs on the audio sample in #1783 with `--word_timestamps True --hallucination_silence_threshold 2`. It includes debug output to show when hallucinations were detected. I can confirm that the results are better on v2 than v3.

<details>
<summary>Sample output</summary>

```
v2 runs:


DETECTED HALLUCINATION: 就這樣子
[00:56.120 --> 00:57.400] 最为开放的领域
[00:57.920 --> 00:59.720] 一个汇聚精英的世界
[01:00.940 --> 01:02.480] 技术与资本联姻
[01:02.480 --> 01:04.640] 成功与风险共存
[01:05.220 --> 01:07.520] 用睿智投资未来
[01:08.200 --> 01:10.980] 百名数字英雄汇聚精诚
[01:10.980 --> 01:12.200] 献计献策
[01:12.200 --> 01:13.900] 共商发展
[01:14.520 --> 01:17.780] 百家讲坛为您奉上精彩系列节目
[01:17.780 --> 01:21.120] 2001北京互联网发展论坛
[01:21.120 --> 01:22.740] 敬请关注
DETECTED HALLUCINATION: 汇聚精英 汇聚精英
[01:51.720 --> 01:53.100] 1995年10月回国
[01:53.720 --> 01:56.420] 1998年成功推出搜狐网站
[01:56.980 --> 01:57.940] 同年10月
[01:57.940 --> 01:59.980] 被美国《时代周刊》评为



DETECTED HALLUCINATION: 了解更多,請訂閱谷歌頻道、按讚、分享、留言 decky born 會開始平台 Seagull Quiz
DETECTED HALLUCINATION: 了解更多,請訂閱谷歌頻道、按讚、分享、留言 decky born 會開始平台 Seagull Quiz
DETECTED HALLUCINATION: 中文字幕由 Amara.org 社群提供
[00:54.080 --> 00:54.920] 互联网
[00:55.600 --> 00:57.400] 一个最为开放的领域
[00:57.900 --> 00:59.740] 一个汇聚精英的世界
[01:01.000 --> 01:02.460] 技术与资本联姻
[01:02.460 --> 01:04.640] 成功与风险共存
[01:05.100 --> 01:07.740] 用睿智投资未来
[01:08.240 --> 01:10.980] 百名数字英雄汇聚精诚
[01:10.980 --> 01:12.200] 献计献策
[01:12.200 --> 01:13.600] 共商发展
[01:14.380 --> 01:17.740] 百家讲坛为您奉上精彩系列节目
[01:19.080 --> 01:21.120] 北京互联网发展论坛
[01:21.120 --> 01:22.800] 敬请关注
[01:35.820 --> 01:36.680] 张昭阳
[01:37.200 --> 01:38.960] 苏护网首席执行官
[01:39.500 --> 01:42.220] 1981年考入清华大学物理系
[01:42.740 --> 01:46.560] 1986年考取李正道奖学金赴美留学
[01:47.140 --> 01:50.460] 七年后获麻省理工学院物理学博士
[01:51.300 --> 01:53.080] 1995年10月回国
[01:53.080 --> 01:56.420] 1998年成功推出苏护网站
[01:56.980 --> 01:59.980] 同年10月被美国时代周刊评为



DETECTED HALLUCINATION: 由 Amara.org 社群提供的字幕
DETECTED HALLUCINATION: 中文字幕由Amara.org社区提供
DETECTED HALLUCINATION: 中文字幕由 Amara.org 社群提供
[00:56.180 --> 00:57.360] 最为开放的领域
[00:57.860 --> 00:59.720] 一个汇聚精英的世界
[01:00.940 --> 01:02.480] 技术与资本联姻
[01:02.480 --> 01:04.640] 成功与风险共存
[01:05.280 --> 01:07.500] 用睿智投资未来
[01:08.200 --> 01:10.980] 百名数字英雄汇聚精诚
[01:10.980 --> 01:12.200] 献计献策
[01:12.200 --> 01:13.600] 共商发展
[01:14.340 --> 01:17.780] 百家讲坛为您奉上精彩系列节目
[01:17.780 --> 01:21.120] 2001北京互联网发展论坛
[01:21.120 --> 01:22.740] 敬请关注
DETECTED HALLUCINATION: 汇聚精英 汇聚精英
[01:53.420 --> 01:56.460] 1998年成功推出搜狐网站
[01:56.960 --> 01:57.920] 同年十月
[01:57.920 --> 01:59.980] 被美国时代周刊评为




DETECTED HALLUCINATION: 哦
DETECTED HALLUCINATION: 中文字幕志愿者申请
[00:58.420 --> 00:59.720] 汇聚精英的世界
[01:00.960 --> 01:02.480] 技术与资本联姻
[01:02.480 --> 01:04.640] 成功与风险共存
[01:04.640 --> 01:07.420] 用睿智投资未来
[01:08.200 --> 01:09.780] 百名数字英雄
[01:09.780 --> 01:10.980] 汇聚精诚
[01:10.980 --> 01:12.200] 献计献策
[01:12.200 --> 01:13.620] 共商发展
[01:14.340 --> 01:15.460] 百家讲坛
[01:15.460 --> 01:17.760] 为您奉上精彩系列节目
[01:18.420 --> 01:21.120] 2001北京互联网发展论坛
[01:21.120 --> 01:22.740] 敬请关注
DETECTED HALLUCINATION: 欢迎订阅
DETECTED HALLUCINATION: 欢迎订阅
DETECTED HALLUCINATION: 欢迎订阅
DETECTED HALLUCINATION: 欢迎订阅
DETECTED HALLUCINATION: 评委书记
[01:39.760 --> 01:42.200] 1981年考入清华大学物理系
[01:42.760 --> 01:44.000] 1986年
[01:44.000 --> 01:45.640] 考取李正道奖学金
[01:45.640 --> 01:46.580] 赴美留学
[01:47.160 --> 01:50.460] 7年后获麻省理工学院物理学博士
[01:51.340 --> 01:53.100] 1995年10月回国
[01:53.100 --> 01:54.580] 1998年
[01:54.580 --> 01:56.440] 成功推出搜狐网站
[01:56.960 --> 01:57.940] 同年10月
[01:57.940 --> 01:59.760] 为美国《时代周刊》
[01:59.760 --> 01:59.980] 评委书记




DETECTED HALLUCINATION: 3
DETECTED HALLUCINATION: 字幕提供者-雪眼唷
DETECTED HALLUCINATION: 中文字幕由 Amara.org 社群提供
[00:54.080 --> 00:54.920] 互联网
[00:55.600 --> 00:57.360] 一个最为开放的领域
[00:57.900 --> 00:59.740] 一个汇聚精英的世界
[01:00.980 --> 01:02.480] 技术与资本联姻
[01:02.480 --> 01:04.640] 成功与风险共存
[01:05.100 --> 01:07.540] 用睿智投资未来
[01:08.240 --> 01:10.980] 百名数字英雄汇聚精诚
[01:10.980 --> 01:12.200] 献计献策
[01:12.200 --> 01:13.560] 共商发展
[01:14.380 --> 01:17.740] 百家讲坛为您奉上精彩系列节目
[01:17.740 --> 01:21.120] 2001北京互联网发展论坛
[01:21.120 --> 01:22.780] 敬请关注
[01:35.780 --> 01:36.700] 张昭阳
[01:37.380 --> 01:38.940] 苏护网首席执行官
[01:39.460 --> 01:42.220] 1981年考入清华大学物理系
[01:42.900 --> 01:46.540] 1986年考取李正道奖学金赴美留学
DETECTED HALLUCINATION: 1997年获麻省理工学院物理学博士
DETECTED HALLUCINATION: 1997年获麻省理工学院物理学博士
DETECTED HALLUCINATION: 定位为苏护网
[01:47.960 --> 01:50.460] 1997年获麻省理工学院物理学博士
[01:51.300 --> 01:53.080] 1995年十月回国
[01:53.080 --> 01:56.420] 1998年成功推出苏护网站
[01:56.980 --> 01:59.460] 同年十月为美国时代周刊
[01:59.460 --> 01:59.980] 定位为苏护网



DETECTED HALLUCINATION: 嗯 рас
DETECTED HALLUCINATION: 嗯 рас
DETECTED HALLUCINATION: 嗯
DETECTED HALLUCINATION: 中文字幕由 Amara.org 社群提供
[00:54.080 --> 00:54.920] 互联网
[00:55.600 --> 00:57.400] 一个最为开放的领域
[00:57.900 --> 00:59.740] 一个汇聚精英的世界
[01:01.000 --> 01:02.460] 技术与资本联姻
[01:02.460 --> 01:04.640] 成功与风险共存
[01:05.100 --> 01:07.740] 用睿智投资未来
[01:08.240 --> 01:10.980] 百名数字英雄汇聚精诚
[01:10.980 --> 01:12.200] 献计献策
[01:12.200 --> 01:13.600] 共商发展
[01:14.380 --> 01:17.740] 百家讲坛为您奉上精彩系列节目
[01:19.080 --> 01:21.120] 北京互联网发展论坛
[01:21.120 --> 01:22.800] 敬请关注
[01:35.820 --> 01:36.680] 张昭阳
[01:37.200 --> 01:38.960] 苏护网首席执行官
[01:39.500 --> 01:42.220] 1981年考入清华大学物理系
[01:42.740 --> 01:46.560] 1986年考取李正道奖学金赴美留学
[01:47.140 --> 01:50.460] 七年后获麻省理工学院物理学博士
[01:51.300 --> 01:53.080] 1995年10月回国
[01:53.080 --> 01:56.420] 1998年成功推出苏护网站
[01:56.980 --> 01:59.980] 同年10月被美国时代周刊评为



[00:21.400 --> 00:23.300] 评估
DETECTED HALLUCINATION: 請不吝點贊訂閱轉發打賞支持明鏡與點點欄目
DETECTED HALLUCINATION: 中文字幕由 Amara.org 社群提供
[00:57.840 --> 00:59.720] 一个汇聚精英的世界
[01:00.940 --> 01:02.480] 技术与资本联姻
[01:02.480 --> 01:04.640] 成功与风险共存
[01:04.640 --> 01:07.480] 用睿智投资未来
[01:08.200 --> 01:10.980] 百名数字英雄汇聚精诚
[01:10.980 --> 01:12.180] 献计献策
[01:12.180 --> 01:13.600] 共商发展
[01:14.340 --> 01:17.760] 百家讲坛为您奉上精彩系列节目
[01:17.760 --> 01:21.120] 2001北京互联网发展论坛
[01:21.120 --> 01:22.740] 敬请关注
DETECTED HALLUCINATION: 汇聚精英 汇聚精英 汇聚精英
[01:54.240 --> 01:56.420] 2018年成功推出搜狐网站
[01:56.960 --> 01:59.980] 同年10月被美国时代周刊定为



v3:

DETECTED HALLUCINATION: 字幕由 Amara.org 社群提供
DETECTED HALLUCINATION: 字幕志愿者 杨栋梁
DETECTED HALLUCINATION: 优优独播剧场——YoYo Television Series Exclusive
DETECTED HALLUCINATION: 请不吝点赞 订阅 转发 打赏支持明镜与点点栏目
[01:03.980 --> 01:21.600] 请不吝点赞 订阅 转发 打赏支持明镜与点点栏目
DETECTED HALLUCINATION: 明镜需要您的支持 欢迎订阅明镜
[01:51.440 --> 01:52.980] 1995年10月回国
[01:52.980 --> 01:56.320] 1998年成功推出搜狐网站
[01:56.320 --> 01:59.940] 同年10月被美国时代周刊评为

```
</details>

Also, this PR includes an option `--clip_timestamps` to specify a list of clips within the audio file where inference should be applied, given in the format `start,end,start,end,...` (each timestamp specified in seconds). For example, `--clip_timestamps 10.5,57.8,71,103` will only run the inference on the region between 10.5 to 57.8 and on the region between 71 to 103. Also, the final `end` will default to the end of the file, so `--clip_timestamps 30` will run inference from the 30 second mark to the end of the file. All timestamps will still be relative to the original audio file. I found this option helpful when testing the hallucination heuristic above, but obviously this option would also be very useful for someone who wants to run their own VAD model on the audio first, and then pass that into `--clip_timestamps`.

One interesting observation is that when running the v3 model on the linked sample audio, we can get very good results if we choose a precise clip region around the 53 second mark (I can't remember now), but if we adjust that forward or backward by very small amounts, we can get the v3 model to completely fail to notice anything that was actually uttered in the audio, suggesting it is a very sensitive model.

I've put each option in a separate commit (happy to split into two PRs if preferred).