### PR TITLE
detect if Mac's Metal Performance Shaders are available

### DIFF
--- a/whisper/__init__.py
+++ b/whisper/__init__.py
@@ -124,7 +124,12 @@ def load_model(
     """
 
     if device is None:
-        device = "cuda" if torch.cuda.is_available() else "cpu"
+        device = "cpu"
+        if torch.cuda.is_available():
+            device = "cuda"
+        elif torch.backends.mps.is_available():
+            device = "mps"
+
     if download_root is None:
         default = os.path.join(os.path.expanduser("~"), ".cache")
         download_root = os.path.join(os.getenv("XDG_CACHE_HOME", default), "whisper")


### PR DESCRIPTION
Default to [Torch's `mps` backend](https://pytorch.org/docs/stable/notes/mps.html) if available when `cuda` is not.