### PR TITLE
Fix triton env marker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ torch
 tqdm
 more-itertools
 tiktoken
+triton>=2.0.0,<3;platform_machine=="x86_64" and sys_platform=="linux" or sys_platform=="linux2"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-import os
 import platform
 import sys
+from pathlib import Path
 
 import pkg_resources
 from setuptools import find_packages, setup
@@ -28,11 +28,10 @@ setup(
     url="https://github.com/openai/whisper",
     license="MIT",
     packages=find_packages(exclude=["tests*"]),
-    install_requires=requirements
-    + [
+    install_requires=[
         str(r)
         for r in pkg_resources.parse_requirements(
-            open(os.path.join(os.path.dirname(__file__), "requirements.txt"))
+            Path(__file__).with_name("requirements.txt").open()
         )
     ],
     entry_points={


### PR DESCRIPTION
I use poetry to manage project dependencies. I want to install `openai-whisper` but failed:

```bash
➜ video-translation (tmp) ✔ poetry add openai-whisper
Using version ^20231117 for openai-whisper

Updating dependencies
Resolving dependencies... (8.3s)

Package operations: 1 install, 1 update, 0 removals

   - Installing triton (2.1.0): Failed

   RuntimeError

   Unable to find installation candidates for triton (2.1.0)

   at ~/workspace/poetry/src/poetry/installation/chooser.py:73 in choose_for
        69│
        70│ links.append(link)
        71│
        72│ if not links:
     → 73│ raise RuntimeError(f"Unable to find installation candidates for {package}")
        74│
        75│ # Get the best link
        76│ chosen = max(links, key=lambda link: self._sort_key(package, link))
        77│

Cannot install triton.
```

However, it should be noted that my computer model is Macbook pro M2. According to the instructions in setup.py, triton should not be installed:

```bash
➜ video-translation (tmp) ✔ uname -s
Darwin
```

After investigation, I found that poetry's dependencies incorrectly included triton. The dependency list was caused by the [following code](https://github.com/169/poetry/blob/6cdc889a2c0c63fea349e93dc3bed5ab875fbe90/src/poetry/inspection/info.py#L248-L251):


```python
            requires = Path(dist.filename) / "requires.txt"
            if requires.exists():
                text = requires.read_text(encoding="utf-8")
                requirements = parse_requires(text)
```

The logic of this code is to download and decompress the `openai-whisper-20231117.tar.gz` file, and obtain the dependency list from the `openai_whisper.egg-info/requires.txt` file.

```bash
➜ video-translation (tmp) ✔ wget https://files.pythonhosted.org/packages/d2/6e/50ace2bf704e5ffc786d20d96403ab0d57c5d6ab8729de7fed8c436687df/openai-whisper-20231117.tar.gz
➜ video-translation (tmp) ✗ tar zxf openai-whisper-20231117.tar.gz
➜ video-translation (tmp) ✗ cd openai-whisper-20231117
➜ openai-whisper-20231117 (tmp) ✗ grep triton openai_whisper.egg-info/requires.txt
triton<3,>=2.0.0
```

According to the current usage, if you are using a Linux system when uploading a package to PYPI, the triton will be written to the `openai_whisper.egg-info/requires.txt` file, which will affect the normal operation of other systems (such as mac, win) use

So I fixed the writing of triton according to https://peps.python.org/pep-0508/#environment-markers. I have tested it in mac and linux environments respectively and made sure it is correct