### PR TITLE
Reduce memory usage in load_audio

### DIFF
--- a/whisper/audio.py
+++ b/whisper/audio.py
@@ -59,7 +59,7 @@ def load_audio(file: str, sr: int = SAMPLE_RATE):
     except CalledProcessError as e:
         raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e
 
-    return np.frombuffer(out, np.int16).flatten().astype(np.float32) / 32768.0
+    return np.frombuffer(out, np.int16).astype(np.float32) / 32768.0
 
 
 def pad_or_trim(array, length: int = N_SAMPLES, *, axis: int = -1):


### PR DESCRIPTION
Removes the call to `flatten()` which creates an in-memory copy of the array, and which seems to be unnecessary since the shape is already flat. Since the array being copied here is the entire uncompressed audio file in raw samples, avoiding the copy significantly reduces peak memory usage and can help very long audio files to fit in systems with constrained memory. Not a general solution to long files (though that would be nice), but just pushes back the memory limits slightly further.