### PR TITLE
Added Unicode not supported Msg for environments that don't support it

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -459,11 +459,14 @@ def transcribe(
                 if last_word_end is not None:
                     last_speech_timestamp = last_word_end
 
-            if verbose:
-                for segment in current_segments:
-                    start, end, text = segment["start"], segment["end"], segment["text"]
-                    line = f"[{format_timestamp(start)} --> {format_timestamp(end)}] {text}"
-                    print(make_safe(line))
+            try:
+                if verbose:
+                    for segment in current_segments:
+                        start, end, text = segment["start"], segment["end"], segment["text"]
+                        line = f"[{format_timestamp(start)} --> {format_timestamp(end)}] {text}"
+                        print(make_safe(line))
+            except Exception as e:
+                print(f"Displaying results skipped due to limitations in the current environment's Unicode support.")
 
             # if a segment is instantaneous or does not contain text, clear it
             for i, segment in enumerate(current_segments):


### PR DESCRIPTION
**To reproduce error:**

```
command_list= ['whisper', 'a.ts', '--language', 'Arabic', '--model', 'small']
speechProccess = subprocess.run(command_list, capture_output = True, text = True)
print(speechProccess.stdout)
print(speechProccess.stderr)
```

In the following error will be output:
```
Skipping a.ts due to UnicodeEncodeError: 'charmap' codec can't encode characters in position 27-29: character maps to <undefined>

Traceback (most recent call last):
  File "C:\Users\abaghdad\AppData\Local\Programs\Python\Python311\Lib\site-packages\whisper\transcribe.py", line 478, in cli
    result = transcribe(model, audio_path, temperature=temperature, **args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\abaghdad\AppData\Local\Programs\Python\Python311\Lib\site-packages\whisper\transcribe.py", line 349, in transcribe
    print(make_safe(line))
  File "C:\Users\abaghdad\AppData\Local\Programs\Python\Python311\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode characters in position 27-29: character maps to <undefined>
```

The modified code adds a try catch over the output so that if it couldn't be converted to Unicode, the model continues to run without returning back to the main function
