### PR TITLE
There are 100 languages instead of 99.

### DIFF
--- a/whisper/model.py
+++ b/whisper/model.py
@@ -274,7 +274,7 @@ class Whisper(nn.Module):
 
     @property
     def num_languages(self):
-        return self.dims.n_vocab - 51765 - int(self.is_multilingual)
+        return self.dims.n_vocab - 51764 - int(self.is_multilingual)
 
     def install_kv_cache_hooks(self, cache: Optional[dict] = None):
         """

--- a/whisper/tokenizer.py
+++ b/whisper/tokenizer.py
@@ -328,7 +328,7 @@ class Tokenizer:
 
 
 @lru_cache(maxsize=None)
-def get_encoding(name: str = "gpt2", num_languages: int = 99):
+def get_encoding(name: str = "gpt2", num_languages: int = 100):
     vocab_path = os.path.join(os.path.dirname(__file__), "assets", f"{name}.tiktoken")
     ranks = {
         base64.b64decode(token): int(rank)
@@ -367,7 +367,7 @@ def get_encoding(name: str = "gpt2", num_languages: int = 99):
 def get_tokenizer(
     multilingual: bool,
     *,
-    num_languages: int = 99,
+    num_languages: int = 100,
     language: Optional[str] = None,
     task: Optional[str] = None,  # Literal["transcribe", "translate", None]
 ) -> Tokenizer:


### PR DESCRIPTION
Example code:
in _STT.py,
```
import whisper
model = whisper.load_model("base")
result = model.transcribe("audio.wav", fp16=False, language="cantonese")
print(result["text"])
```

Error:
```
Traceback (most recent call last):
  File "c:\Users\ABC\Desktop\New folder (2)\_STT.py", line 4, in <module>
    result = model.transcribe("tacotron2-DDC.wav", fp16=False, language="cantonese")
  File "C:\Users\ABC\Desktop\New folder (2)\.venv\lib\site-packages\whisper\transcribe.py", line 155, in transcribe    tokenizer = get_tokenizer(
  File "C:\Users\ABC\Desktop\New folder (2)\.venv\lib\site-packages\whisper\tokenizer.py", line 393, in get_tokenizer
    return Tokenizer(
  File "<string>", line 9, in __init__
  File "C:\Users\ABC\Desktop\New folder (2)\.venv\lib\site-packages\whisper\tokenizer.py", line 154, in __post_init__
    sot_sequence.append(sot + 1 + langs.index(self.language))
ValueError: tuple.index(x): x not in tuple
```

The reason error occur is that cantonese is omitted by the code, which assummes 99 languages, when there are acutally 100 languages. cantonese is the last one in the language list.
