### PR TITLE
add repeat audio back

### DIFF
--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -730,7 +730,8 @@ class DecodingTask:
                 )
             ]
 
-        # repeat text tensors by the group size, for beam search or best-of-n sampling
+        # repeat the audio & text tensors by the group size, for beam search or best-of-n sampling
+        audio_features = audio_features.repeat_interleave(self.n_group, dim=0)
         tokens = tokens.repeat_interleave(self.n_group, dim=0).to(audio_features.device)
 
         # call the main sampling loop


### PR DESCRIPTION
Related to #1483.

I have encountered issues when decoding with beam_size > 1. 

Here, https://github.com/openai/whisper/blob/main/whisper/model.py#L102, during cross_attention, I think we must keep the first two dims of query and key tensors same. However, I didn't find anywhere we repeat the audio or key, value tensors with beam_size.

