### PR TITLE
Prevent infinite loop for out-of-bound timestamps in clip_timestamps

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -261,6 +261,8 @@ def transcribe(
         #     while seek < seek_clip_end
         while clip_idx < len(seek_clips):
             seek_clip_start, seek_clip_end = seek_clips[clip_idx]
+            if seek_clip_end > content_frames:
+                seek_clip_end = content_frames
             if seek < seek_clip_start:
                 seek = seek_clip_start
             if seek >= seek_clip_end:


### PR DESCRIPTION
I'm using the output of `get_speech_timestamps` in Silero VAD to produce values for `clip_timestamps`.

The VAD produces an end timestamp that is one-sample beyond the last found voice sample. I was converting these timestamps into seconds and passing them directly into `clip_timestamps`.

The problem is sometimes the end timestamp would be one sample past the end of the file. In this case, whisper would go into an infinite loop, trying to run inference on segment_size of 0. 
