### PR TITLE
Fix window end heuristic for hallucination_silence_threshold

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -402,14 +402,6 @@ def transcribe(
                 # skip silence before possible hallucinations
                 if hallucination_silence_threshold is not None:
                     threshold = hallucination_silence_threshold
-                    if not single_timestamp_ending:
-                        last_word_end = get_end(current_segments)
-                        if last_word_end is not None and last_word_end > time_offset:
-                            remaining_duration = window_end_time - last_word_end
-                            if remaining_duration > threshold:
-                                seek = round(last_word_end * FRAMES_PER_SECOND)
-                            else:
-                                seek = previous_seek + segment_size
 
                     # if first segment might be a hallucination, skip leading silence
                     first_segment = next_words_segment(current_segments)


### PR DESCRIPTION
Removes the end-of-window heuristic mentioned in https://github.com/openai/whisper/pull/1838#issuecomment-1960858735 which was causing it to (too) opportunistically skip over the silence at the end of the window when sometimes it was not in fact silence.

Its removal unmasks the similar block directly above it which should work well enough in this case:

```python
                if not single_timestamp_ending:
                    last_word_end = get_end(current_segments)
                    if last_word_end is not None and last_word_end > time_offset:
                        seek = round(last_word_end * FRAMES_PER_SECOND)
```