### PR TITLE
add hotwords feature

### DIFF
--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -112,6 +112,7 @@ class DecodingOptions:
 
     # implementation details
     fp16: bool = True  # use fp16 for most of the calculation
+    hotwords: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -598,15 +599,22 @@ class DecodingTask:
                 prefix_tokens = prefix_tokens[-max_prefix_len:]
             tokens = tokens + prefix_tokens
 
-        if prompt := self.options.prompt:
+        if (prompt := self.options.prompt) or ((self.options.hotwords) and not self.options.prefix):
             prompt_tokens = (
                 self.tokenizer.encode(" " + prompt.strip())
                 if isinstance(prompt, str)
                 else prompt
             )
+            if (hotwords := self.options.hotwords) and not self.options.prefix:
+                print(f"hotwords: {hotwords}")
+                hotwords_tokens = self.tokenizer.encode(" " + hotwords.strip())
+                if len(hotwords_tokens) >= self.n_ctx // 2:
+                    hotwords_tokens = hotwords_tokens[: self.n_ctx // 2 - 1]
             tokens = (
                 [self.tokenizer.sot_prev]
                 + prompt_tokens[-(self.n_ctx // 2 - 1) :]
+                + (hotwords_tokens if self.options.hotwords is not None else [])
+                + (prompt_tokens[-(self.n_ctx // 2 - 1) :] if self.options.prompt is not None else [])
                 + tokens
             )
 


### PR DESCRIPTION
hello!
During the transcription process, I often encounter some proprietary or new vocabulary, and Whisper cannot handle it well. I searched for solutions, and the community provided two options:

Fine-tuning the model: This approach is costly, and it's not practical to fine-tune the model every time a new term emerges.

Using initial_prompt: However, initial_prompt only applies to the first window. If specialized terms don't appear at the beginning, this method is ineffective.

Upon reviewing other transcription models, it's common practice to use hotwords. So, I implemented this feature. My approach is to add hotword-related prompts before each transcription window. Since there's a maximum length limit, I occupy the space previously used by the prefix. When the prefix isn't set, hotwords take effect. After testing, it indeed resolved the issue of specialized vocabulary in my scenario.

The following is the community discussion on this issue:
https://github.com/openai/whisper/discussions/1477
https://discuss.huggingface.co/t/adding-custom-vocabularies-on-whisper/29311
https://stackoverflow.com/questions/73833916/how-can-i-give-some-hint-phrases-to-openais-whisper-asr