### PR TITLE
Hiding the ffmpeg popup that appears momentarily

### DIFF
--- a/whisper/audio.py
+++ b/whisper/audio.py
@@ -1,6 +1,6 @@
 import os
 from functools import lru_cache
-from subprocess import CalledProcessError, run, CREATE_NO_WINDOW
+from subprocess import CalledProcessError, run
 from typing import Optional, Union
 
 import numpy as np
@@ -57,6 +57,7 @@ def load_audio(file: str, sr: int = SAMPLE_RATE):
     try:
         creationflags = None
         if os.name == 'nt':
+            from subprocess import CREATE_NO_WINDOW
             creationflags = CREATE_NO_WINDOW
         out = run(cmd, capture_output=True, check=True, creationflags=creationflags).stdout
     except CalledProcessError as e:

--- a/whisper/audio.py
+++ b/whisper/audio.py
@@ -55,7 +55,10 @@ def load_audio(file: str, sr: int = SAMPLE_RATE):
     ]
     # fmt: on
     try:
-        out = run(cmd, capture_output=True, check=True, creationflags=CREATE_NO_WINDOW).stdout
+        creationflags = None
+        if os.name == 'nt':
+            creationflags = CREATE_NO_WINDOW
+        out = run(cmd, capture_output=True, check=True, creationflags=creationflags).stdout
     except CalledProcessError as e:
         raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e
 

--- a/whisper/audio.py
+++ b/whisper/audio.py
@@ -1,6 +1,6 @@
 import os
 from functools import lru_cache
-from subprocess import CalledProcessError, run
+from subprocess import CalledProcessError, run, CREATE_NO_WINDOW
 from typing import Optional, Union
 
 import numpy as np
@@ -55,7 +55,7 @@ def load_audio(file: str, sr: int = SAMPLE_RATE):
     ]
     # fmt: on
     try:
-        out = run(cmd, capture_output=True, check=True).stdout
+        out = run(cmd, capture_output=True, check=True, creationflags=CREATE_NO_WINDOW).stdout
     except CalledProcessError as e:
         raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e
 


### PR DESCRIPTION
On Windows there is a problem due to which FFMPEG running in the background becomes small for a second during startup.

Context: "Whisper" is used in conjunction with FastAPI and uvicorn. The service is started using pm2.

The problem does not exist if you run it manually from a regular console using "python main.py"

Demonstration of the problem before and after
https://youtu.be/IsEavmzQOv8