### PR TITLE
Add `enable_generator` in `transcribe()`

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -501,6 +501,7 @@ def transcribe(
                     text=tokenizer.decode(all_tokens[len(initial_prompt_tokens) :]),
                     segments=all_segments,
                     language=language,
+                    content_duration=content_duration
                 )
 
     return dict(

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -51,6 +51,7 @@ def transcribe(
     append_punctuations: str = "\"'.。,，!！?？:：”)]}、",
     clip_timestamps: Union[str, List[float]] = "0",
     hallucination_silence_threshold: Optional[float] = None,
+    enable_generator: bool = False,
     **decode_options,
 ):
     """
@@ -112,6 +113,10 @@ def transcribe(
     hallucination_silence_threshold: Optional[float]
         When word_timestamps is True, skip silent periods longer than this threshold (in seconds)
         when a possible hallucination is detected
+
+    enable_generator: bool
+        Whether to use a generator for output. If True, yields incremental results as a generator.
+        If False, returns the complete transcription results as a dictionary.
 
     Returns
     -------
@@ -490,6 +495,13 @@ def transcribe(
 
             # update progress bar
             pbar.update(min(content_frames, seek) - previous_seek)
+
+            if enable_generator:
+                yield dict(
+                    text=tokenizer.decode(all_tokens[len(initial_prompt_tokens) :]),
+                    segments=all_segments,
+                    language=language,
+                )
 
     return dict(
         text=tokenizer.decode(all_tokens[len(initial_prompt_tokens) :]),


### PR DESCRIPTION
Hi, sincere thanks for running open source.
Could I use the generator with `transcribe()`?

This is useful for tracking progress,
For example : `progress = result["segments"][-1]["start"] / result["content_duration"]` .