### PR TITLE
Add error handling to log_mel_spectrogram function

### DIFF
--- a/whisper/audio.py
+++ b/whisper/audio.py
@@ -140,6 +140,9 @@ def log_mel_spectrogram(
             audio = load_audio(audio)
         audio = torch.from_numpy(audio)
 
+    if len(audio) < N_SAMPLES:  # Check if audio length is less than expected
+        raise ValueError("Input audio length is shorter than the expected length.")
+
     if device is not None:
         audio = audio.to(device)
     if padding > 0:


### PR DESCRIPTION
This pull request adds error handling to the log_mel_spectrogram function in order to improve robustness and provide clearer feedback to users when input audio is shorter than the expected length. 

Previously, the function would proceed with processing the audio even if it was shorter than the expected length, potentially leading to unexpected behavior or errors downstream. With this enhancement, the function now raises a ValueError if the input audio is shorter than the expected length, ensuring that users are informed of the issue and preventing further processing with insufficient data.

Changes:

- Added error handling to check if the input audio is shorter than the expected length (N_SAMPLES) before proceeding with processing.
- Raised a ValueError if the input audio is shorter than the expected length, providing clearer feedback to users.
Testing:

Tested the modified log_mel_spectrogram function with various input audio files, including files shorter than the expected length, to ensure that the error handling works as intended and that the function raises a ValueError in such cases.
Verified that the function behaves as expected and produces correct outputs for audio files of sufficient length.

This enhancement improves the reliability and usability of the log_mel_spectrogram function, making it more robust in handling different input scenarios :)