### PR TITLE
Fix beam search with batch processing in Whisper decoding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,4 +53,4 @@ jobs:
       - uses: actions/checkout@v3
       - run: echo "$CONDA/envs/test/bin" >> $GITHUB_PATH
       - run: pip install .["dev"]
-      - run: pytest --durations=0 -vv -k 'not test_transcribe or test_transcribe[tiny] or test_transcribe[tiny.en]' -m 'not requires_cuda'
+      - run: pytest --durations=0 -vv -k 'not (test_transcribe or test_decode) or test_transcribe[tiny] or test_transcribe[tiny.en] or test_decode[tiny] or test_decode[tiny.en]' -m 'not requires_cuda'

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -1,0 +1,52 @@
+import os
+
+import pytest
+import torch
+
+import whisper
+
+
+@pytest.mark.parametrize("model_name", whisper.available_models())
+def test_decode(model_name: str):
+    # Regression test: batch_size and beam_size should work together
+    beam_size = 2
+    batch_size = 2
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = whisper.load_model(model_name).to(device)
+    audio_path = os.path.join(os.path.dirname(__file__), "jfk.flac")
+
+    language = "en" if model_name.endswith(".en") else None
+
+    options = whisper.DecodingOptions(language=language, beam_size=beam_size)
+
+    audio = whisper.load_audio(audio_path)
+    audio = whisper.pad_or_trim(audio)
+    mel = whisper.log_mel_spectrogram(audio).to(device)
+
+    # Create a small batch
+    batch_mel = mel.unsqueeze(0).repeat(batch_size, 1, 1)
+
+    results = model.decode(batch_mel, options)
+
+    # Since both examples are the same, results should be identical
+    assert len(results) == batch_size
+    assert results[0].text == results[1].text
+
+    decoded_text = results[0].text.lower()
+    assert "my fellow americans" in decoded_text
+    assert "your country" in decoded_text
+    assert "do for you" in decoded_text
+
+    timing_checked = False
+    if hasattr(results[0], "segments"):
+        for segment in results[0].segments:
+            for timing in segment["words"]:
+                assert timing["start"] < timing["end"]
+                if timing["word"].strip(" ,") == "Americans":
+                    assert timing["start"] <= 1.8
+                    assert timing["end"] >= 1.8
+                    timing_checked = True
+
+    if hasattr(results[0], "segments"):
+        assert timing_checked

--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -731,6 +731,9 @@ class DecodingTask:
             ]
 
         # repeat text tensors by the group size, for beam search or best-of-n sampling
+        audio_features = audio_features.repeat_interleave(self.n_group, dim=0).to(
+            audio_features.device
+        )
         tokens = tokens.repeat_interleave(self.n_group, dim=0).to(audio_features.device)
 
         # call the main sampling loop


### PR DESCRIPTION
When using the Whisper model's `decode()` method with both `beam_size` and `batch_size` greater than 1, a dimension mismatch error occurs. This issue was apparently introduced accidentally in PR #1483.

### Example to Reproduce de Error

```python
import torch
import whisper

device = "cuda" if torch.cuda.is_available() else "cpu"
model = whisper.load_model("tiny").to(device)

# load audio and pad/trim it to fit 30 seconds
audio = whisper.load_audio("tests/jfk.flac")
audio = whisper.pad_or_trim(audio)
mel = whisper.log_mel_spectrogram(audio).to(model.device)

# Create a small batch with 2 examples
batch_mel = mel.unsqueeze(0).repeat(2, 1, 1)

# decode the audio with beam size > 1
options = whisper.DecodingOptions(beam_size=5)
results = model.decode(batch_mel, options)

# print the recognized text
for result in results:
    print(result.text)
```

This outputs the following error:

```
Traceback (most recent call last):
  File "decode_example.py", line 17, in <module>
    results = model.decode(batch_mel, options)
  File "~/.anaconda3/envs/whisper-dev/lib/python3.8/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "~/src/whisper/whisper/decoding.py", line 824, in decode
    result = DecodingTask(model, options).run(mel)
  File "~/.anaconda3/envs/whisper-dev/lib/python3.8/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "~/src/whisper/whisper/decoding.py", line 737, in run
    tokens, sum_logprobs, no_speech_probs = self._main_loop(audio_features, tokens)
  File "~/src/whisper/whisper/decoding.py", line 687, in _main_loop
    logits = self.inference.logits(tokens, audio_features)
  File "~/src/whisper/whisper/decoding.py", line 163, in logits
    return self.model.decoder(tokens, audio_features, kv_cache=self.kv_cache)
  File "~/.anaconda3/envs/whisper-dev/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "~/src/whisper/whisper/model.py", line 211, in forward
    x = block(x, xa, mask=self.mask, kv_cache=kv_cache)
  File "~/.anaconda3/envs/whisper-dev/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "~/src/whisper/whisper/model.py", line 138, in forward
    x = x + self.cross_attn(self.cross_attn_ln(x), xa, kv_cache=kv_cache)[0]
  File "~/.anaconda3/envs/whisper-dev/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "~/src/whisper/whisper/model.py", line 90, in forward
    wv, qk = self.qkv_attention(q, k, v, mask)
  File "~/src/whisper/whisper/model.py", line 102, in qkv_attention
    qk = q @ k
RuntimeError: The size of tensor a (10) must match the size of tensor b (2) at non-singleton dimension 0
```

### Solution

* Ensure that audio features are correctly duplicated across beams for each batch item.
* Add a test for `decode()` that includes a regression test for this.
* Update `.github/workflows/test.yml` to run the new test for `decode()`.