### PR TITLE
Fix: typo in dataset reference text

### DIFF
--- a/notebooks/LibriSpeech.ipynb
+++ b/notebooks/LibriSpeech.ipynb
@@ -249,7 +249,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>Stuffered into you, his belly counseled him.</td>\n",
+       "      <td>Stuffed into you, his belly counseled him.</td>\n",
        "      <td>STUFF IT INTO YOU HIS BELLY COUNSELLED HIM</td>\n",
        "    </tr>\n",
        "    <tr>\n",


### PR DESCRIPTION
- Changed "Stuffered into you, his belly counseled him." to "Stuffed into you, his belly counseled him."