### PR TITLE
Pin numpy to 1.26.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numba
-numpy
+numpy==1.26.4
 torch
 tqdm
 more-itertools


### PR DESCRIPTION
whisper is not compatible with numpy 2.x so pin to highest 1.x version