### PR TITLE
Fix for ffmpeg return code false positive errors

### DIFF
--- a/whisper/audio.py
+++ b/whisper/audio.py
@@ -51,15 +51,16 @@ def load_audio(file: str, sr: int = SAMPLE_RATE):
         "-ac", "1",
         "-acodec", "pcm_s16le",
         "-ar", str(sr),
+        "-loglevel", "error",
         "-"
     ]
     # fmt: on
-    try:
-        out = run(cmd, capture_output=True, check=True).stdout
-    except CalledProcessError as e:
-        raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e
+    result = run(cmd, capture_output=True)
 
-    return np.frombuffer(out, np.int16).flatten().astype(np.float32) / 32768.0
+    if len(result.stderr):
+        raise RuntimeError(f"Failed to load audio: {result.stderr.decode()}")
+
+    return np.frombuffer(result.stdout, np.int16).flatten().astype(np.float32) / 32768.0
 
 
 def pad_or_trim(array, length: int = N_SAMPLES, *, axis: int = -1):


### PR DESCRIPTION
This is a fix for `ffmpeg` return code errors that tend to happen only on windows when some of the binary output from the `ffmpeg` call spills over in the terminal and is interpreted as non-zero return code from the process.

Below is an example of a `ffmpeg` call on a system that exhibits this problem.
![ffmpeg-binary-output](https://github.com/user-attachments/assets/f38a7c4c-16de-4c33-b635-c49a84b12704)

Binary data has corrupted the terminal formatting and part of it sits as input.