### PR TITLE
repeats audio_features tensor, just like tokens tensor, by group size…

### DIFF
--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -732,6 +732,7 @@ class DecodingTask:
 
         # repeat text tensors by the group size, for beam search or best-of-n sampling
         tokens = tokens.repeat_interleave(self.n_group, dim=0).to(audio_features.device)
+        audio_features = audio_features.repeat_interleave(self.n_group, dim=0).to(audio_features.device)
 
         # call the main sampling loop
         tokens, sum_logprobs, no_speech_probs = self._main_loop(audio_features, tokens)


### PR DESCRIPTION
… for beam search or best-of-n sampling.

If run with batch of size 1, the current code does not raise an error, because of Pytorch's Broadcasting. But by bigger batch sizes it raises error.