### PR TITLE
add TranscribeProgressReceiver for update monitoring

### DIFF
--- a/whisper/__init__.py
+++ b/whisper/__init__.py
@@ -11,7 +11,7 @@ from tqdm import tqdm
 from .audio import load_audio, log_mel_spectrogram, pad_or_trim
 from .decoding import DecodingOptions, DecodingResult, decode, detect_language
 from .model import ModelDimensions, Whisper
-from .transcribe import transcribe
+from .transcribe import TranscribeProgressReceiver, transcribe
 from .version import __version__
 
 _MODELS = {


### PR DESCRIPTION
Current `transcribe` API only outputs the progress and transcribed texts on stdout. Callers can only access the result after the whole transcription is done, and they need to hijack `tqdm` interface to get the realtime transcription progress(AFAIK [like this](https://github.com/openai/whisper/discussions/850#discussioncomment-5443424)). This commit adds a simple interface that can be passed as a parameter in `transcribe` so the API users don't need to fallback to above hacks or low-level APIs for this need.