### PR TITLE
Update `setup.py` to accommodate `Python3.13.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,13 @@ from setuptools import find_packages, setup
 
 
 def read_version(fname="whisper/version.py"):
-    exec(compile(open(fname, encoding="utf-8").read(), fname, "exec"))
-    return locals()["__version__"]
+    frame_locals = {}
+    exec(
+        compile(open(fname, encoding="utf-8").read(), fname, "exec"),
+        globals(),
+        frame_locals,
+    )
+    return frame_locals["__version__"]
 
 
 requirements = []


### PR DESCRIPTION
*Changes made*

- Update `setup.py` to pass in a local dictionary to `exec` to capture the `locals()` in `_version.py` for package version reporting.

*Motivation*

- `Python3.13.0` enforces stricter safety standards on `locals()` with PEP 667 (see [here](https://github.com/python/cpython/issues/118888#issuecomment-2104944287))

- This causes the following error upon attempting to install with `python3.13 -m pip install openai-whisper`:

```bash
Collecting openai-whisper
  Using cached openai-whisper-20240930.tar.gz (800 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [25 lines of output]
      <string>:5: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
      Traceback (most recent call last):
        File "/Users/jasonshipp/.pyenv/versions/3.13.0/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
          ~~~~^^
        File "/Users/jasonshipp/.pyenv/versions/3.13.0/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/jasonshipp/.pyenv/versions/3.13.0/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/private/var/folders/hk/8xz63_l16zb9snz57jx9hqgr0000gn/T/pip-build-env-l_19mrvs/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 332, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/hk/8xz63_l16zb9snz57jx9hqgr0000gn/T/pip-build-env-l_19mrvs/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 302, in _get_build_requires
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File "/private/var/folders/hk/8xz63_l16zb9snz57jx9hqgr0000gn/T/pip-build-env-l_19mrvs/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 516, in run_setup
          super().run_setup(setup_script=setup_script)
          ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/hk/8xz63_l16zb9snz57jx9hqgr0000gn/T/pip-build-env-l_19mrvs/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 318, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "<string>", line 21, in <module>
        File "<string>", line 11, in read_version
      KeyError: '__version__'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip
```

*EXTRA NOTES*

- This does not enable `openai-whisper` to be pip installed with `Python3.13`, due to a dependency on the `numba` library. This issue and missing dependency can be tracked [here](https://github.com/numba/numba/issues/9413)