### PR TITLE
setup.py: Remove deprecated `pkg_resources` in favor of `importlib.util`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,16 @@
+import importlib.util
 import platform
 import sys
 from pathlib import Path
 
-import pkg_resources
 from setuptools import find_packages, setup
 
 
 def read_version(fname="whisper/version.py"):
-    exec(compile(open(fname, encoding="utf-8").read(), fname, "exec"))
-    return locals()["__version__"]
+    spec = importlib.util.spec_from_file_location("version", fname)
+    version_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(version_module)
+    return version_module.__version__
 
 
 requirements = []

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import platform
 import sys
 from pathlib import Path
 
+from packaging.requirements import Requirement
 from setuptools import find_packages, setup
 
 
@@ -11,6 +12,11 @@ def read_version(fname="whisper/version.py"):
     version_module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(version_module)
     return version_module.__version__
+
+
+def parse_requirements(file_path = Path(__file__).with_name("requirements.txt")):
+    lines = file_path.read_text(encoding="utf-8").splitlines()
+    return [str(Requirement(line)) for line in lines if not line.startswith("#")]
 
 
 requirements = []
@@ -30,12 +36,7 @@ setup(
     url="https://github.com/openai/whisper",
     license="MIT",
     packages=find_packages(exclude=["tests*"]),
-    install_requires=[
-        str(r)
-        for r in pkg_resources.parse_requirements(
-            Path(__file__).with_name("requirements.txt").open()
-        )
-    ],
+    install_requires=parse_requirements(Path(__file__).with_name("requirements.txt")),
     entry_points={
         "console_scripts": ["whisper=whisper.transcribe:cli"],
     },


### PR DESCRIPTION
Remove deprecated `pkg_resources` in favor of `importlib.util`.

Fixes this warning at install-time:
> DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html