### PR TITLE
Add support for leading zero in transcription when spoken by user

### DIFF
--- a/whisper/normalizers/english.py
+++ b/whisper/normalizers/english.py
@@ -208,6 +208,10 @@ class EnglishNumberNormalizer:
                 prefix = current[0] if has_prefix else prefix
                 if f.denominator == 1:
                     value = f.numerator  # store integers as int
+                    # count the number of leading zeros and add back all leading zeros if they were removed
+                    leading_zeros = len(current_without_prefix) - len(current_without_prefix.lstrip('0'))
+                    if leading_zeros > 0 and value != 0:
+                        value = "0" * leading_zeros + str(value)             
                 else:
                     value = current_without_prefix
             elif current not in self.words:


### PR DESCRIPTION
This pull request addresses an issue where leading zeros in numbers were not preserved in the transcription when explicitly spoken by the user. e.g. AB01234 was normalized as AB 1234. The changes ensure that the transcription includes leading zeros when they are intentionally voiced, by add back the zero after `to_fraction`