### PR TITLE
GitHub Actions: Add Python 3.13 to the testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
     needs: pre-commit
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - python-version: '3.8'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,10 @@ jobs:
             pytorch-version: 2.4.1
             numpy-requirement: "'numpy'"
           - python-version: '3.12'
-            pytorch-version: 2.5.0
+            pytorch-version: 2.5.1
+            numpy-requirement: "'numpy'"
+          - python-version: '3.13'
+            pytorch-version: 2.5.1
             numpy-requirement: "'numpy'"
     steps:
       - uses: conda-incubator/setup-miniconda@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,7 @@ classifiers = [
 dynamic = [ "version" ]
 dependencies = [
   "more-itertools",
-  "numba; python_version<'3.13'",
-  "numba==0.61.0rc2; python_version=='3.13'",
+  "numba",
   "numpy",
   "tiktoken",
   "torch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ classifiers = [
 dynamic = [ "version" ]
 dependencies = [
   "more-itertools",
-  "numba",
+  "numba; python_version<'3.13'",
+  "numba==0.61.0rc2; python_version=='3.13'",
   "numpy",
   "tiktoken",
   "torch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "tiktoken",
   "torch",
   "tqdm",
-  "triton>=2; (platform_machine=='x86_64' and sys_platform=='linux') or sys_platform=='linux2'",
+  "triton>=2; python_version<'3.13' and (platform_machine=='x86_64' and sys_platform=='linux') or sys_platform=='linux2'",
 ]
 optional-dependencies.dev = [ "black", "flake8", "isort", "pytest", "scipy" ]
 urls = { Homepage = "https://github.com/openai/whisper" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "tiktoken",
   "torch",
   "tqdm",
-  "triton>=2; python_version<'3.13' and (platform_machine=='x86_64' and sys_platform=='linux') or sys_platform=='linux2'",
+  "triton>=2; (platform_machine=='x86_64' and sys_platform=='linux') or sys_platform=='linux2'",
 ]
 optional-dependencies.dev = [ "black", "flake8", "isort", "pytest", "scipy" ]
 urls = { Homepage = "https://github.com/openai/whisper" }


### PR DESCRIPTION
Python 3.13 was blocked waiting on
`numba>=0.61.0` -- https://pypi.org/project/numba/#history and
`triton>3.1.0` -- https://pypi.org/project/triton/#history
but now the PyPI releases of both are compatible with Python 3.13.
* https://github.com/triton-lang/triton/issues/5215
