### PR TITLE
device usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Adding `--task translate` will translate the speech into English:
 
     whisper japanese.wav --language Japanese --task translate
 
+Adding `--device cuda:<n>` will use the selected cuda GPU number
+
+    whisper japanese.wav --language Japanese --task translate --device cuda:1
+
 Run the following to view all available options:
 
     whisper --help


### PR DESCRIPTION
it is not explained how to select a specific GPU, as neither of
`--device 1`
`--device nvidia1`
`--device /dev/nvidia1`
work.

`--device cuda:<n>` does, but is not intuitive so I suggest this example addition.