### PR TITLE
Add Capability to specify FFMPEG Path to Whisperer

### DIFF
--- a/whisper/__init__.py
+++ b/whisper/__init__.py
@@ -50,6 +50,8 @@ _ALIGNMENT_HEADS = {
     "turbo": b"ABzY8j^C+e0{>%RARaKHP%t(lGR*)0g!tONPyhe`",
 }
 
+ffmpeg_path: str = "ffmpeg"
+
 
 def _download(url: str, root: str, in_memory: bool) -> Union[bytes, str]:
     os.makedirs(root, exist_ok=True)

--- a/whisper/audio.py
+++ b/whisper/audio.py
@@ -7,6 +7,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
+import whisper
 from .utils import exact_div
 
 # hard-coded audio hyperparameters
@@ -43,7 +44,7 @@ def load_audio(file: str, sr: int = SAMPLE_RATE):
     # and resampling as necessary.  Requires the ffmpeg CLI in PATH.
     # fmt: off
     cmd = [
-        "ffmpeg",
+        whisper.ffmpeg_path,
         "-nostdin",
         "-threads", "0",
         "-i", file,


### PR DESCRIPTION
### Description of the Issue

There are scenarios where specifying a default `ffmpeg` executable path is essential for achieving desired functionality. By default, the program attempts to use the globally available `ffmpeg` command, but this approach might not always work.

For instance, a common error that users may encounter is:  
```
ERROR - Error in transcribe_and_save: [Errno 2] No such file or directory: 'ffmpeg'
```

This error often arises when `ffmpeg` is not properly installed or accessible due to specific system configurations. Even after installing `ffmpeg`, users might face challenges if their environment is not set up correctly.

### Proposed Solution

To make configuration more flexible and user-friendly, this update allows users to explicitly specify the path to the `ffmpeg` executable. By setting the path programmatically, users can avoid system-level issues and ensure the correct executable is used.

Here’s an example of how this can be configured:

```python
import whisper

# Specify the path to the ffmpeg executable
whisper.ffmpeg_path = "/usr/bin/ffmpeg"

# Load the model and transcribe audio
model = whisper.load_model("turbo")
result = model.transcribe("audio.mp3")
print(result["text"])
```

### Benefits

- **Improved Flexibility**: Users can define the `ffmpeg` path based on their specific environment, bypassing global configuration issues.
- **Error Prevention**: Reduces errors caused by missing or improperly configured `ffmpeg` installations.
- **Ease of Use**: Provides a straightforward way for users to resolve potential issues without extensive debugging.