### PR TITLE
pre-commit: Upgrade black v25.1.0 and isort v6.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,11 @@ repos:
       - id: check-added-large-files
         args: [--maxkb=4096]
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
       - id: isort
         name: isort (python)


### PR DESCRIPTION
% `pre-commit autoupdate`
[https://github.com/pre-commit/pre-commit-hooks] already up to date!
[https://github.com/psf/black] updating 24.10.0 -> 25.1.0
[https://github.com/pycqa/isort] updating 5.13.2 -> 6.0.0
[https://github.com/pycqa/flake8.git] already up to date!
% `pre-commit run --all-files`

https://github.com/psf/black/blob/main/CHANGES.md#2510
> This release introduces the new 2025 stable style

https://github.com/pycqa/isort/releases
> Python 3.13 support...