### PR TITLE
Text Censoring

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -549,13 +549,11 @@ def transcribe(
     if censor:
         text = censor_text(text, forbidden_words)
 
-    data = dict(
+    return dict(
         text=text,
         segments=all_segments,
         language=language,
     )
-
-    return data
 
 
 def cli():


### PR DESCRIPTION
Text censoring has been implemented to allow users to filter out words from a list they create themselves. The format will be a json format using {lang: [words]} to allow multi language censoring. censor must be set to True and a path must be entered for it to work. Checks have been put in place to ensure if the path is incorrect, cannot be found, or cannot be opened, the censor will turn off and the program will run as normal.