### PR TITLE
Use predictable URL sub-path.

### DIFF
--- a/whisper/__init__.py
+++ b/whisper/__init__.py
@@ -54,8 +54,8 @@ _ALIGNMENT_HEADS = {
 def _download(url: str, root: str, in_memory: bool) -> Union[bytes, str]:
     os.makedirs(root, exist_ok=True)
 
-    expected_sha256 = url.split("/")[-2]
-    download_target = os.path.join(root, os.path.basename(url))
+    expected_sha256, basename = url.split("/")[-2:]
+    download_target = os.path.join(root, basename)
 
     if os.path.exists(download_target) and not os.path.isfile(download_target):
         raise RuntimeError(f"{download_target} exists and is not a regular file")


### PR DESCRIPTION
`os.path` expects local OS specific identifiers and may not be reliable for URLs. Using existing `url.split()` values avoids any potential issues and also eliminates a redundant function operation.