### PR TITLE
docs: update README to reflect supported Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Transformer sequence-to-sequence model is trained on various speech processing
 
 ## Setup
 
-We used Python 3.9.9 and [PyTorch](https://pytorch.org/) 1.10.1 to train and test our models, but the codebase is expected to be compatible with Python 3.8-3.11 and recent PyTorch versions. The codebase also depends on a few Python packages, most notably [OpenAI's tiktoken](https://github.com/openai/tiktoken) for their fast tokenizer implementation. You can download and install (or update to) the latest release of Whisper with the following command:
+We used Python 3.9.9 and [PyTorch](https://pytorch.org/) 1.10.1 to train and test our models, but the codebase is expected to be compatible with Python 3.8-3.13 and recent PyTorch versions. The codebase also depends on a few Python packages, most notably [OpenAI's tiktoken](https://github.com/openai/tiktoken) for their fast tokenizer implementation. You can download and install (or update to) the latest release of Whisper with the following command:
 
     pip install -U openai-whisper
 


### PR DESCRIPTION
This PR updates the README to reflect that Whisper is compatible with Python 3.8–3.13, rather than 3.8–3.11.

The CI workflow in `.github/workflows/test.yml` runs the test suite across Python 3.8, 3.9, 3.10, 3.11, 3.12 and 3.13.  All of these versions are tested regularly, so updating the documentation to 3.8–3.13 improves accuracy.

No code changes are needed; this is a documentation update only.