### PR TITLE
Fix for pytorch version check issue in __init__.py 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tqdm
 more-itertools
 tiktoken
 triton>=2.0.0;platform_machine=="x86_64" and sys_platform=="linux" or sys_platform=="linux2"
+packaging

--- a/whisper/__init__.py
+++ b/whisper/__init__.py
@@ -13,6 +13,7 @@ from .decoding import DecodingOptions, DecodingResult, decode, detect_language
 from .model import ModelDimensions, Whisper
 from .transcribe import transcribe
 from .version import __version__
+from pkg_resources import packaging
 
 _MODELS = {
     "tiny.en": "https://openaipublic.azureedge.net/main/whisper/models/d3dd57d32accea0b295c96e26691aa14d8822fac7d9d27d5dc00b4ca2826dd03/tiny.en.pt",
@@ -147,7 +148,7 @@ def load_model(
     with (
         io.BytesIO(checkpoint_file) if in_memory else open(checkpoint_file, "rb")
     ) as fp:
-        kwargs = {"weights_only": True} if torch.__version__ >= "1.13" else {}
+        kwargs = {"weights_only": True} if packaging.version.parse(torch.__version__ ) >= packaging.version.parse("1.13") else {}
         checkpoint = torch.load(fp, map_location=device, **kwargs)
     del checkpoint_file
 

--- a/whisper/__init__.py
+++ b/whisper/__init__.py
@@ -4,6 +4,7 @@ import os
 import urllib
 import warnings
 from typing import List, Optional, Union
+from packaging import version
 
 import torch
 from tqdm import tqdm
@@ -13,7 +14,6 @@ from .decoding import DecodingOptions, DecodingResult, decode, detect_language
 from .model import ModelDimensions, Whisper
 from .transcribe import transcribe
 from .version import __version__
-from pkg_resources import packaging
 
 _MODELS = {
     "tiny.en": "https://openaipublic.azureedge.net/main/whisper/models/d3dd57d32accea0b295c96e26691aa14d8822fac7d9d27d5dc00b4ca2826dd03/tiny.en.pt",
@@ -148,7 +148,7 @@ def load_model(
     with (
         io.BytesIO(checkpoint_file) if in_memory else open(checkpoint_file, "rb")
     ) as fp:
-        kwargs = {"weights_only": True} if packaging.version.parse(torch.__version__ ) >= packaging.version.parse("1.13") else {}
+        kwargs = {"weights_only": True} if version.parse(torch.__version__ ) >= version.parse("1.13") else {}
         checkpoint = torch.load(fp, map_location=device, **kwargs)
     del checkpoint_file
 


### PR DESCRIPTION
This is the solution as mentioned in the discussion #2660 
It fixes for Pytorch version check issue for adding 'weights_only' argument. Added a more accurate version parser. 

Original Code:
```
kwargs = {"weights_only": True} if torch.__version__ >= "1.13" else {}
```

Fixed Version Check using Version Parser:
```
from packaging import version
kwargs = {"weights_only": True} if version.parse(torch.__version__ ) >= version.parse("1.13") else {}
```