### PR TITLE
Fix: float64 error when enbling word_timestamps on mac with mps

### DIFF
--- a/whisper/timing.py
+++ b/whisper/timing.py
@@ -148,7 +148,7 @@ def dtw(x: torch.Tensor) -> np.ndarray:
                 "falling back to a slower DTW implementation..."
             )
 
-    return dtw_cpu(x.double().cpu().numpy())
+    return dtw_cpu(x.cpu().double().numpy())
 
 
 @dataclass


### PR DESCRIPTION
Enabling wordtimestamps on mac with mps resulted in an error in the dtw function, as it tries to cast a torch.Tensor to a double (float64), which is not supported by mps. The fix consists in calling .cpu() on the torch.Tensor before casting it to a double instead of after.