### PR TITLE
fix: raise TypeError instead of returning it

### DIFF
--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -657,7 +657,7 @@ class DecodingTask:
         if audio_features.dtype != (
             torch.float16 if self.options.fp16 else torch.float32
         ):
-            return TypeError(
+            raise TypeError(
                 f"audio_features has an incorrect dtype: {audio_features.dtype}"
             )
 


### PR DESCRIPTION
## Bug
`return TypeError(...)` on line 660 of `whisper/decoding.py` silently returns an exception object as the function's return value instead of actually raising the error. This means callers receive a TypeError object instead of getting a proper exception, which would cause confusing downstream failures.

## Fix
Changed `return TypeError(...)` to `raise TypeError(...)` so the error is properly raised when `audio_features` has an incorrect dtype.