### PR TITLE
Fix resource leaks and typos across whisper package

### DIFF
--- a/whisper/__init__.py
+++ b/whisper/__init__.py
@@ -89,7 +89,7 @@ def _download(url: str, root: str, in_memory: bool) -> Union[bytes, str]:
     model_bytes = open(download_target, "rb").read()
     if hashlib.sha256(model_bytes).hexdigest() != expected_sha256:
         raise RuntimeError(
-            "Model has been downloaded but the SHA256 checksum does not not match. Please retry loading the model."
+            "Model has been downloaded but the SHA256 checksum does not match. Please retry loading the model."
         )
 
     return model_bytes if in_memory else download_target
@@ -137,7 +137,11 @@ def load_model(
         checkpoint_file = _download(_MODELS[name], download_root, in_memory)
         alignment_heads = _ALIGNMENT_HEADS[name]
     elif os.path.isfile(name):
-        checkpoint_file = open(name, "rb").read() if in_memory else name
+        if in_memory:
+            with open(name, "rb") as f:
+                checkpoint_file = f.read()
+        else:
+            checkpoint_file = name
         alignment_heads = None
     else:
         raise RuntimeError(

--- a/whisper/tokenizer.py
+++ b/whisper/tokenizer.py
@@ -330,10 +330,11 @@ class Tokenizer:
 @lru_cache(maxsize=None)
 def get_encoding(name: str = "gpt2", num_languages: int = 99):
     vocab_path = os.path.join(os.path.dirname(__file__), "assets", f"{name}.tiktoken")
-    ranks = {
-        base64.b64decode(token): int(rank)
-        for token, rank in (line.split() for line in open(vocab_path) if line)
-    }
+    with open(vocab_path) as vocab_file:
+        ranks = {
+            base64.b64decode(token): int(rank)
+            for token, rank in (line.split() for line in vocab_file if line)
+        }
     n_vocab = len(ranks)
     special_tokens = {}
 

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -577,7 +577,7 @@ def cli():
     if model_name.endswith(".en") and args["language"] not in {"en", "English"}:
         if args["language"] is not None:
             warnings.warn(
-                f"{model_name} is an English-only model but receipted '{args['language']}'; using English instead."
+                f"{model_name} is an English-only model but received '{args['language']}'; using English instead."
             )
         args["language"] = "en"
 


### PR DESCRIPTION
## Summary

- **Fix file descriptor leak in `load_model()`** (`whisper/__init__.py`): When loading a custom model checkpoint path with `in_memory=True`, the file was opened via `open(name, "rb").read()` without a `with` statement, leaking the file descriptor. Now uses a context manager to ensure proper cleanup.

- **Fix file descriptor leak in `get_encoding()`** (`whisper/tokenizer.py`): The vocab `.tiktoken` file was opened inside a dict comprehension (`open(vocab_path)`) without ever being closed. The file handle was only released when the garbage collector ran. Wrapped in a `with` statement for deterministic cleanup.

- **Fix double-negation typo in error message** (`whisper/__init__.py`): The SHA256 checksum mismatch error message read *"does not not match"* instead of *"does not match"*.

- **Fix typo in CLI warning** (`whisper/transcribe.py`): Changed *"receipted"* to *"received"* in the English-only model language mismatch warning.

## Test plan

- [ ] Verify `load_model()` with a custom checkpoint path and `in_memory=True` opens and closes the file handle properly
- [ ] Verify `get_encoding()` no longer leaves file handles open after reading the tiktoken vocab file
- [ ] Verify the SHA256 error message reads correctly: "does not match"
- [ ] Verify the CLI warning message reads correctly: "received"
- [ ] Run existing test suite: `pytest tests/`