### PR TITLE
Fix: Enforce fail-fast output_dir validation with argparse and OS W_O…

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -524,13 +524,23 @@ def cli():
             f"model should be one of {available_models()} or path to a model checkpoint"
         )
 
+    def valid_output_dir(path):
+        try:
+            os.makedirs(path, exist_ok=True)
+        except Exception as e:
+            raise argparse.ArgumentTypeError(f"Cannot create output directory {path}: {e}")
+        
+        if not os.access(path, os.W_OK | os.X_OK):
+            raise argparse.ArgumentTypeError(f"Lack write/execute permission for output directory: {path}")
+        return path
+
     # fmt: off
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("audio", nargs="+", type=str, help="audio file(s) to transcribe")
     parser.add_argument("--model", default="turbo", type=valid_model_name, help="name of the Whisper model to use")
     parser.add_argument("--model_dir", type=str, default=None, help="the path to save model files; uses ~/.cache/whisper by default")
     parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu", help="device to use for PyTorch inference")
-    parser.add_argument("--output_dir", "-o", type=str, default=".", help="directory to save the outputs")
+    parser.add_argument("--output_dir", "-o", type=valid_output_dir, default=".", help="directory to save the outputs")
     parser.add_argument("--output_format", "-f", type=str, default="all", choices=["txt", "vtt", "srt", "tsv", "json", "all"], help="format of the output file; if not specified, all available formats will be produced")
     parser.add_argument("--verbose", type=str2bool, default=True, help="whether to print out the progress and debug messages")
 
@@ -572,7 +582,6 @@ def cli():
     output_dir: str = args.pop("output_dir")
     output_format: str = args.pop("output_format")
     device: str = args.pop("device")
-    os.makedirs(output_dir, exist_ok=True)
 
     if model_name.endswith(".en") and args["language"] not in {"en", "English"}:
         if args["language"] is not None:
@@ -592,9 +601,10 @@ def cli():
 
     from . import load_model
 
+    writer = get_writer(output_format, output_dir)
+
     model = load_model(model_name, device=device, download_root=model_dir)
 
-    writer = get_writer(output_format, output_dir)
     word_options = [
         "highlight_words",
         "max_line_count",

--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -86,6 +86,12 @@ class ResultWriter:
     extension: str
 
     def __init__(self, output_dir: str):
+        if not os.path.exists(output_dir):
+            raise FileNotFoundError(f"Output directory does not exist: {output_dir}")
+        if not os.path.isdir(output_dir):
+            raise NotADirectoryError(f"Output path is not a directory: {output_dir}")
+        if not os.access(output_dir, os.W_OK | os.X_OK):
+            raise PermissionError(f"Lack write/execute permission for output directory: {output_dir}")
         self.output_dir = output_dir
 
     def __call__(


### PR DESCRIPTION
**Problem**
Currently, Whisper does not eagerly validate if the destination --output_dir provided by the user is valid, accessible, or capable of being created. Because directory creation (os.makedirs) and file writing operations execute lazily deep within the pipeline, passing an invalid destination causes the application to:

Load multiple gigabytes of models into memory unnecessarily.
In the case of API consumers, successfully finish an entire 10+ minute ML transcription process only to immediately crash and lose all generated data with a massive Python stack trace (FileNotFoundError or PermissionError) right as it attempts to save the subtitle files.


**Solution**
This PR strictly enforces "fail-fast" behavior for output configuration to protect against wasted compute time and poor CLI UX.

Key Changes:

(CLI) Native Argparse Validation: Created a valid_output_dir type boundary inside whisper/transcribe.py.
argparse now safely intercepts the os.makedirs() step during argument parsing.
If creation fails or write-permissions are missing, the CLI exits instantly before touching torch, providing a clean POSIX-standard whisper: error: argument --output_dir/-o output rather than an unhandled traceback.
(API) Robust Access Bitmasking: Updated whisper/utils.py:ResultWriter to validate upon instantiation. It strictly validates both os.W_OK | os.X_OK, which guarantees the running process genuinely has traversing and writing permissions on Unix/Linux file systems before consumers initiate heavy tasks.