### PR TITLE
Fix silent TypeError, resource leaks, typos, and CUDA skip logic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,21 @@ import random as rand
 
 import numpy
 import pytest
+import torch
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "requires_cuda")
+    config.addinivalue_line(
+        "markers", "requires_cuda: mark test as requiring a CUDA GPU"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if not torch.cuda.is_available():
+        skip_cuda = pytest.mark.skip(reason="CUDA not available")
+        for item in items:
+            if item.get_closest_marker("requires_cuda"):
+                item.add_marker(skip_cuda)
 
 
 @pytest.fixture

--- a/whisper/__init__.py
+++ b/whisper/__init__.py
@@ -86,10 +86,11 @@ def _download(url: str, root: str, in_memory: bool) -> Union[bytes, str]:
                 output.write(buffer)
                 loop.update(len(buffer))
 
-    model_bytes = open(download_target, "rb").read()
+    with open(download_target, "rb") as f:
+        model_bytes = f.read()
     if hashlib.sha256(model_bytes).hexdigest() != expected_sha256:
         raise RuntimeError(
-            "Model has been downloaded but the SHA256 checksum does not not match. Please retry loading the model."
+            "Model has been downloaded but the SHA256 checksum does not match. Please retry loading the model."
         )
 
     return model_bytes if in_memory else download_target
@@ -137,7 +138,11 @@ def load_model(
         checkpoint_file = _download(_MODELS[name], download_root, in_memory)
         alignment_heads = _ALIGNMENT_HEADS[name]
     elif os.path.isfile(name):
-        checkpoint_file = open(name, "rb").read() if in_memory else name
+        if in_memory:
+            with open(name, "rb") as f:
+                checkpoint_file = f.read()
+        else:
+            checkpoint_file = name
         alignment_heads = None
     else:
         raise RuntimeError(

--- a/whisper/audio.py
+++ b/whisper/audio.py
@@ -136,7 +136,7 @@ def log_mel_spectrogram(
         A Tensor that contains the Mel spectrogram
     """
     if not torch.is_tensor(audio):
-        if isinstance(audio, str):
+        if isinstance(audio, (str, os.PathLike)):
             audio = load_audio(audio)
         audio = torch.from_numpy(audio)
 

--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -657,7 +657,7 @@ class DecodingTask:
         if audio_features.dtype != (
             torch.float16 if self.options.fp16 else torch.float32
         ):
-            return TypeError(
+            raise TypeError(
                 f"audio_features has an incorrect dtype: {audio_features.dtype}"
             )
 

--- a/whisper/normalizers/english.py
+++ b/whisper/normalizers/english.py
@@ -456,7 +456,8 @@ class EnglishSpellingNormalizer:
 
     def __init__(self):
         mapping_path = os.path.join(os.path.dirname(__file__), "english.json")
-        self.mapping = json.load(open(mapping_path))
+        with open(mapping_path) as f:
+            self.mapping = json.load(f)
 
     def __call__(self, s: str):
         return " ".join(self.mapping.get(word, word) for word in s.split())

--- a/whisper/tokenizer.py
+++ b/whisper/tokenizer.py
@@ -330,10 +330,11 @@ class Tokenizer:
 @lru_cache(maxsize=None)
 def get_encoding(name: str = "gpt2", num_languages: int = 99):
     vocab_path = os.path.join(os.path.dirname(__file__), "assets", f"{name}.tiktoken")
-    ranks = {
-        base64.b64decode(token): int(rank)
-        for token, rank in (line.split() for line in open(vocab_path) if line)
-    }
+    with open(vocab_path) as vocab_file:
+        ranks = {
+            base64.b64decode(token): int(rank)
+            for token, rank in (line.split() for line in vocab_file if line)
+        }
     n_vocab = len(ranks)
     special_tokens = {}
 

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -577,7 +577,7 @@ def cli():
     if model_name.endswith(".en") and args["language"] not in {"en", "English"}:
         if args["language"] is not None:
             warnings.warn(
-                f"{model_name} is an English-only model but receipted '{args['language']}'; using English instead."
+                f"{model_name} is an English-only model but received '{args['language']}'; using English instead."
             )
         args["language"] = "en"
 


### PR DESCRIPTION
- decoding.py: `return TypeError(...)` → `raise TypeError(...)` so dtype mismatches in `_get_audio_features` are actually surfaced instead of returning the exception object as a value
- __init__.py, tokenizer.py, normalizers/english.py: replace bare `open()` calls with context managers to ensure file handles are closed promptly
- __init__.py: fix double-word typo "does not not match"
- transcribe.py: fix typo "receipted" → "received"
- audio.py: accept `os.PathLike` (e.g. `pathlib.Path`) in `log_mel_spectrogram`, not just `str`
- tests/conftest.py: enforce `requires_cuda` marker as a proper skip when CUDA is unavailable, instead of only registering the marker name