### PR TITLE
Fix UnicodeEncodeError when printing verbose log

### DIFF
--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -5,7 +5,7 @@ import sys
 import zlib
 from typing import Callable, List, Optional, TextIO
 
-system_encoding = sys.getdefaultencoding()
+system_encoding = sys.stdout.encoding
 
 if system_encoding != "utf-8":
 


### PR DESCRIPTION
In non utf-8 console e.g. Windows when using `powershell -Command "Measure-Command { whisper ...}"` in cp950 system, printing the character which is not in cp950 will cause UnicodeEncodeError:

```
File "C:\Users\desktop\AppData\Roaming\uv\tools\openai-whisper\Lib\site-packages\whisper\transcribe.py", line 482, in transcribe
    print(make_safe(line))
UnicodeEncodeError: 'cp950' codec can't encode character '\u4eec' in position 30: illegal multibyte sequence
```

This is because of `make_safe` in utils.py used `sys.getdefaultencoding()` to determine the output encoding when printing transcription logs in verbose mode. However, this function returns the default encoding for `str.encode()` and its constant 'utf-8', which does not reflect the actual stdout encoding.

> ## sys.getdefaultencoding()
> Return 'utf-8'. This is the name of the default string encoding, used in methods like [str.encode()](https://docs.python.org/3/library/stdtypes.html#str.encode).

Reference: https://docs.python.org/3/library/sys.html#sys.getdefaultencoding

Replace it with `sys.stdout.encoding`, by the document, stdout is regular text file that can get its encoding by `.encoding` which correctly represents the encoding of the current output stream for `print()`.

Reference: https://docs.python.org/3/library/sys.html#sys.stdout