### PR TITLE
Make solution.patch

### DIFF
--- a/solution.patch
+++ b/solution.patch
@@ -1,0 +1,69 @@
+diff --git a/.github/workflows/python-publish.yml b/.github/workflows/python-publish.yml
+index ff8f122..f70e0a3 100644
+--- a/.github/workflows/python-publish.yml
++++ b/.github/workflows/python-publish.yml
+@@ -8,14 +8,14 @@ jobs:
+   deploy:
+     runs-on: ubuntu-latest
+     steps:
+-    - uses: actions/checkout@v4
+-    - uses: actions-ecosystem/action-regex-match@v2
++    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
++    - uses: actions-ecosystem/action-regex-match@9e6c4fb3d5e898f505be7a1fb6e7b0a278f6665b # v2
+       id: regex-match
+       with:
+         text: ${{ github.event.head_commit.message }}
+         regex: '^Release ([^ ]+)'
+     - name: Set up Python
+-      uses: actions/setup-python@v5
++      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+       with:
+         python-version: '3.12'
+     - name: Install dependencies
+@@ -24,7 +24,7 @@ jobs:
+         pip install setuptools wheel twine build
+     - name: Release
+       if: ${{ steps.regex-match.outputs.match != '' }}
+-      uses: softprops/action-gh-release@v2
++      uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+       with:
+         tag_name: v${{ steps.regex-match.outputs.group1 }}
+     - name: Build and publish
+diff --git a/.github/workflows/test.yml b/.github/workflows/test.yml
+index 3b53de8..a37a88f 100644
+--- a/.github/workflows/test.yml
++++ b/.github/workflows/test.yml
+@@ -11,10 +11,10 @@ jobs:
+   pre-commit:
+     runs-on: ubuntu-latest
+     steps:
+-      - uses: actions/checkout@v4
++      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+       - name: Fetch base branch
+         run: git fetch origin ${{ github.base_ref }}
+-      - uses: actions/setup-python@v5
++      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+         with:
+           python-version: "3.9"
+           architecture: x64
+@@ -23,7 +23,7 @@ jobs:
+         run: |
+           echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+       - name: pip/pre-commit cache
+-        uses: actions/cache@v4
++        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+         with:
+           path: |
+             ${{ steps.pip-cache.outputs.dir }}
+@@ -71,9 +71,9 @@ jobs:
+             pytorch-version: 2.5.1
+             numpy-requirement: "'numpy'"
+     steps:
+-      - uses: conda-incubator/setup-miniconda@v3
++      - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3
+       - run: conda install -n test ffmpeg python=${{ matrix.python-version }}
+-      - uses: actions/checkout@v4
++      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+       - run: echo "$CONDA/envs/test/bin" >> $GITHUB_PATH
+       - run: pip3 install .["dev"] ${{ matrix.numpy-requirement }} torch==${{ matrix.pytorch-version }}+cpu --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple
+       - run: pytest --durations=0 -vv -k 'not test_transcribe or test_transcribe[tiny] or test_transcribe[tiny.en]' -m 'not requires_cuda'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use pinned commit SHAs for all third-party actions instead of floating version tags. This change enhances security and reproducibility by ensuring that workflows always use the exact same version of each action.

**Workflow security and reproducibility improvements:**

* Updated all third-party GitHub Actions in `.github/workflows/python-publish.yml` and `.github/workflows/test.yml` to use specific commit SHAs instead of version tags, including `actions/checkout`, `actions/setup-python`, `actions/cache`, `actions-ecosystem/action-regex-match`, `softprops/action-gh-release`, and `conda-incubator/setup-miniconda`.