### PR TITLE
Improve ffmpeg missing error message in load_audio()

### DIFF
--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,6 +1,8 @@
 import os.path
+from unittest.mock import patch
 
 import numpy as np
+import pytest
 
 from whisper.audio import SAMPLE_RATE, load_audio, log_mel_spectrogram
 
@@ -17,3 +19,10 @@ def test_audio():
 
     assert np.allclose(mel_from_audio, mel_from_file)
     assert mel_from_audio.max() - mel_from_audio.min() <= 2.0
+
+
+def test_load_audio_missing_ffmpeg():
+    with patch("whisper.audio.run", side_effect=FileNotFoundError):
+        with pytest.raises(RuntimeError) as exc_info:
+            load_audio("dummy.wav")
+    assert "ffmpeg was not found" in str(exc_info.value)

--- a/whisper/audio.py
+++ b/whisper/audio.py
@@ -56,6 +56,10 @@ def load_audio(file: str, sr: int = SAMPLE_RATE):
     # fmt: on
     try:
         out = run(cmd, capture_output=True, check=True).stdout
+    except FileNotFoundError:
+        raise RuntimeError(
+            "ffmpeg was not found. Please install it from https://ffmpeg.org"
+        )
     except CalledProcessError as e:
         raise RuntimeError(f"Failed to load audio: {e.stderr.decode()}") from e
 


### PR DESCRIPTION
## Summary

Improve the error message shown when `ffmpeg` is not installed and `load_audio()` is called.

Currently, users receive a generic subprocess-related exception which does not clearly explain that `ffmpeg` is missing from the system.

This PR:

* catches `FileNotFoundError`
* raises a clearer `RuntimeError`
* points users directly to the ffmpeg installation page
* adds tests covering the new behavior

## Changes

* Added explicit `FileNotFoundError` handling in `whisper/audio.py`
* Added regression tests in `tests/test_audio.py`

## Why

`ffmpeg` is a common dependency issue for first-time Whisper users. A more explicit error message improves debugging and onboarding without changing runtime behavior for valid installations.
