### PR TITLE
Avoid adding empty words list to segments when word_timestamps is False

### DIFF
--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -486,7 +486,8 @@ def transcribe(
                 if segment["start"] == segment["end"] or segment["text"].strip() == "":
                     segment["text"] = ""
                     segment["tokens"] = []
-                    segment["words"] = []
+                    if "words" in segment:
+                        segment["words"] = []
 
             all_segments.extend(
                 [


### PR DESCRIPTION
When word_timestamps is False, segments do not have a `words` key. The cleanup pass for instantaneous or empty segments was unconditionally assigning `segment['words'] = []`, introducing the key only on those empty segments. This makes the segment schema inconsistent: some segments get a `words` key, others do not.

`SubtitlesWriter` (used by both WriteVTT and WriteSRT) decides which iteration path to take by checking `'words' in result['segments'][0]`. If the first segment happens to be empty or instantaneous, that spurious key flips the writer into the word-level path, which then raises `KeyError: 'words'` on the next non-empty segment that lacks the key.

Minimal reproducer:

```python
from whisper.utils import WriteSRT
import io

result = {
    'segments': [
        {'id': 0, 'seek': 0, 'start': 0.0, 'end': 0.0, 'text': '',
         'tokens': [], 'words': [],  # would be set by transcribe.py
         'temperature': 0.0, 'avg_logprob': -0.5,
         'compression_ratio': 1.5, 'no_speech_prob': 0.1},
        {'id': 1, 'seek': 0, 'start': 1.0, 'end': 3.0, 'text': 'Hello',
         'tokens': [1, 2, 3],  # no 'words' key, word_timestamps=False
         'temperature': 0.0, 'avg_logprob': -0.5,
         'compression_ratio': 1.5, 'no_speech_prob': 0.1},
    ],
}
WriteSRT('/tmp').write_result(result, file=io.StringIO())
# KeyError: 'words'
```

Fix: only reset `words` when the key is already present, matching how `add_word_timestamps` populates it. Behavior when `word_timestamps=True` is unchanged (the key is present, gets cleared to `[]` as before).