### PR TITLE
Fix double negation in SHA256 mismatch error message

### DIFF
--- a/whisper/__init__.py
+++ b/whisper/__init__.py
@@ -89,7 +89,7 @@ def _download(url: str, root: str, in_memory: bool) -> Union[bytes, str]:
     model_bytes = open(download_target, "rb").read()
     if hashlib.sha256(model_bytes).hexdigest() != expected_sha256:
         raise RuntimeError(
-            "Model has been downloaded but the SHA256 checksum does not not match. Please retry loading the model."
+            "Model has been downloaded but the SHA256 checksum does not match. Please retry loading the model."
         )
 
     return model_bytes if in_memory else download_target


### PR DESCRIPTION
whisper/__init__.py line 93 currently reads 'does not not match' in the SHA256 verification error. The double negative reads as 'does match' to careful eyes. Drop the duplicate 'not'.