### PR TITLE
Fix #2730: fix: raise TypeError instead of returning it

### DIFF
--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -657,7 +657,7 @@ class DecodingTask:
         if audio_features.dtype != (
             torch.float16 if self.options.fp16 else torch.float32
         ):
-            return TypeError(
+            raise TypeError(
                 f"audio_features has an incorrect dtype: {audio_features.dtype}"
             )
 


### PR DESCRIPTION
Fixes #2730

Changed `return TypeError(...)` to `raise TypeError(...)` on line 660 of `whisper/decoding.py` so the error is properly raised instead of silently returned as a value.

Local test infra unavailable in CI sandbox.

---
This change was prepared with AI assistance under human direction and review.