### PR TITLE
Accept common CLI boolean values

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,27 @@
+import pytest
+
+from whisper.utils import str2bool
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("True", True),
+        ("False", False),
+        ("true", True),
+        ("false", False),
+        ("TRUE", True),
+        ("FALSE", False),
+        ("1", True),
+        ("0", False),
+        ("yes", True),
+        ("no", False),
+    ],
+)
+def test_str2bool_accepts_common_boolean_spellings(value, expected):
+    assert str2bool(value) is expected
+
+
+def test_str2bool_rejects_invalid_values():
+    with pytest.raises(ValueError, match="Expected a boolean value"):
+        str2bool("maybe")

--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -27,11 +27,18 @@ def exact_div(x, y):
 
 
 def str2bool(string):
-    str2val = {"True": True, "False": False}
-    if string in str2val:
-        return str2val[string]
-    else:
-        raise ValueError(f"Expected one of {set(str2val.keys())}, got {string}")
+    str2val = {
+        "true": True,
+        "false": False,
+        "1": True,
+        "0": False,
+        "yes": True,
+        "no": False,
+    }
+    value = str2val.get(string.lower())
+    if value is None:
+        raise ValueError(f"Expected a boolean value, got {string}")
+    return value
 
 
 def optional_int(string):


### PR DESCRIPTION
## Summary

Accept common CLI boolean spellings in `str2bool` so command-line flags like `--fp16 false`, `--verbose false`, and `--word_timestamps true` work in addition to the current `True`/`False` values.

## Changes

- Normalize boolean arguments case-insensitively.
- Accept `true`/`false`, `1`/`0`, and `yes`/`no`.
- Add focused tests for accepted and rejected values.

## Validation

- `python3 -m pytest tests/test_utils.py tests/test_tokenizer.py tests/test_normalizer.py -q`
- `python3 -m pytest tests/test_utils.py tests/test_audio.py tests/test_tokenizer.py tests/test_normalizer.py tests/test_timing.py -q -m 'not requires_cuda'`
- `python3 -m pytest tests -q -m 'not requires_cuda' --ignore=tests/test_transcribe.py`
- `python3 -m black --check whisper/utils.py tests/test_utils.py`
- `python3 -m isort --check-only whisper/utils.py tests/test_utils.py`
- `python3 -m flake8 tests/test_utils.py`

Notes:
- I did not run `tests/test_transcribe.py` because it downloads/runs every model.
- Running timing tests without filtering `requires_cuda` fails on this machine because the installed PyTorch build has no CUDA support; the non-CUDA run passed with 28 passed and 8 deselected.
