### PR TITLE
Normalize the ordinal "ninth" to "9th"

### DIFF
--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -32,6 +32,9 @@ def test_number_normalizer(std):
     assert std("nineteen fifties") == "1950s"
     assert std("thirty first") == "31st"
     assert std("thirty three thousand and three hundred and thirty third") == "33333rd"
+    assert std("ninth") == "9th"
+    assert std("twenty ninth") == "29th"
+    assert std("one hundred and ninth") == "109th"
 
     assert std("three billion") == "3000000000"
     assert std("millions") == "1000000s"

--- a/whisper/normalizers/english.py
+++ b/whisper/normalizers/english.py
@@ -61,11 +61,12 @@ class EnglishNumberNormalizer:
             "second": (2, "nd"),
             "third": (3, "rd"),
             "fifth": (5, "th"),
+            "ninth": (9, "th"),
             "twelfth": (12, "th"),
             **{
                 name + ("h" if name.endswith("t") else "th"): (value, "th")
                 for name, value in self.ones.items()
-                if value > 3 and value != 5 and value != 12
+                if value > 3 and value != 5 and value != 9 and value != 12
             },
         }
         self.ones_suffixed = {**self.ones_plural, **self.ones_ordinal}


### PR DESCRIPTION
The English number normalizer builds ordinal words by adding "th" to the cardinal word, with a few hardcoded exceptions (first, second, third, fifth, eighth, twelfth). "nine" was missing from those exceptions, so the rule produced "nineth", which nobody writes, and the real word "ninth" was never recognized.

As a result "ninth" was left as text instead of "9th", and compound ordinals broke: "twenty ninth" came out as "20 ninth" and "one hundred and ninth" as "100 and ninth".

Added "ninth" to the hardcoded ordinals and excluded 9 from the generated rule. Added tests for the simple and compound cases.