### PR TITLE
feat: add transcription progress callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ result = model.transcribe("audio.mp3")
 print(result["text"])
 ```
 
+To receive transcription progress in an application, pass a callback that accepts a float from `0` to `1`:
+
+```python
+def on_progress(progress: float):
+    print(f"Transcription: {progress:.0%}")
+
+
+result = model.transcribe("audio.mp3", progress_callback=on_progress)
+```
+
 Internally, the `transcribe()` method reads the entire file and processes the audio with a sliding 30-second window, performing autoregressive sequence-to-sequence predictions on each window.
 
 Below is an example usage of `whisper.detect_language()` and `whisper.decode()` which provide lower-level access to the model.

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -12,11 +12,19 @@ def test_transcribe(model_name: str):
     device = "cuda" if torch.cuda.is_available() else "cpu"
     model = whisper.load_model(model_name).to(device)
     audio_path = os.path.join(os.path.dirname(__file__), "jfk.flac")
+    progress = []
 
     language = "en" if model_name.endswith(".en") else None
     result = model.transcribe(
-        audio_path, language=language, temperature=0.0, word_timestamps=True
+        audio_path,
+        language=language,
+        temperature=0.0,
+        word_timestamps=True,
+        progress_callback=progress.append,
     )
+    assert progress
+    assert progress == sorted(progress)
+    assert progress[-1] == pytest.approx(1.0)
     assert result["language"] == "en"
     assert result["text"] == "".join([s["text"] for s in result["segments"]])
 

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import traceback
 import warnings
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -40,6 +40,7 @@ def transcribe(
     audio: Union[str, np.ndarray, torch.Tensor],
     *,
     verbose: Optional[bool] = None,
+    progress_callback: Optional[Callable[[float], None]] = None,
     temperature: Union[float, Tuple[float, ...]] = (0.0, 0.2, 0.4, 0.6, 0.8, 1.0),
     compression_ratio_threshold: Optional[float] = 2.4,
     logprob_threshold: Optional[float] = -1.0,
@@ -68,6 +69,10 @@ def transcribe(
     verbose: bool
         Whether to display the text being decoded to the console. If True, displays all the details,
         If False, displays minimal details. If None, does not display anything
+
+    progress_callback: Optional[Callable[[float], None]]
+        Optional callback invoked with the overall transcription progress as a float from 0 to 1
+        after each decoded segment.
 
     temperature: Union[float, Tuple[float, ...]]
         Temperature for sampling. It can be a tuple of temperatures, which will be successively used
@@ -264,6 +269,7 @@ def transcribe(
     with tqdm.tqdm(
         total=content_frames, unit="frames", disable=verbose is not False
     ) as pbar:
+        last_progress = 0.0
         last_speech_timestamp = 0.0
         # NOTE: This loop is obscurely flattened to make the diff readable.
         # A later commit should turn this into a simpler nested loop.
@@ -506,6 +512,14 @@ def transcribe(
 
             # update progress bar
             pbar.update(min(content_frames, seek) - previous_seek)
+            if progress_callback is not None:
+                progress = (
+                    min(content_frames, seek) / content_frames
+                    if content_frames > 0
+                    else 1.0
+                )
+                last_progress = max(last_progress, progress)
+                progress_callback(last_progress)
 
     return dict(
         text=tokenizer.decode(all_tokens[len(initial_prompt_tokens) :]),


### PR DESCRIPTION
## What changed

Adds an explicit `progress_callback` keyword to `whisper.transcribe`.

The callback receives a monotonic float from `0.0` to `1.0` after each decoded segment. It is kept separate from `**decode_options`, so it cannot be accidentally forwarded to `DecodingOptions`.

Also adds:

- a README usage example
- integration assertions in `tests/test_transcribe.py` for callback invocation, monotonicity, and completion

## Why

Discussion #2810 reports that users reasonably try to pass a progress callback, but the unknown `progress` keyword is forwarded into `DecodingOptions` and raises:

```
TypeError: DecodingOptions.__init__() got an unexpected keyword argument 'progress'
```

This adds a small backwards-compatible API for applications that need progress without monkey-patching the internal `tqdm` implementation. Existing callers are unchanged.

## Validation

- `python -m compileall -q whisper/transcribe.py tests/test_transcribe.py`
- AST check confirms the new keyword-only parameter
- `git diff --check`
- README callback snippet reviewed

The full model integration test was not runnable in this checkout because PyTorch is not installed; CI can run the existing model matrix.