### PR TITLE
Fix: SDPA cross-attention falling back to the math kernel

### DIFF
--- a/whisper/model.py
+++ b/whisper/model.py
@@ -121,6 +121,13 @@ class MultiHeadAttention(nn.Module):
         v = v.view(*v.shape[:2], self.n_head, -1).permute(0, 2, 1, 3)
 
         if SDPA_AVAILABLE and MultiHeadAttention.use_sdpa:
+            if k.shape[0] == 1 and q.shape[0] != 1:
+                # Cross-attention K/V have batch 1 and broadcast against the
+                # beam-expanded query; the fused SDPA kernels reject the batch
+                # mismatch and fall back to math, so expand K/V to a stride-0
+                # view (no copy) to keep them on the fast path.
+                k = k.expand(q.shape[0], *k.shape[1:])
+                v = v.expand(q.shape[0], *v.shape[1:])
             a = scaled_dot_product_attention(
                 q, k, v, is_causal=mask is not None and n_ctx > 1
             )


### PR DESCRIPTION
Since #2359 routed attention through `scaled_dot_product_attention`,
cross-attention loses fused-kernel acceleration whenever `beam_size > 1` or
`best_of > 1`. The cross-attention K/V are computed once from the audio
(batch 1) and broadcast against the beam-expanded query batch; the flash and
memory-efficient SDPA kernels reject the batch mismatch and silently fall
back to the unfused "math" kernel for every cross-attention call.

This expands the cached K/V to a stride-0 view (no copy) so the batch
dimensions match and the fused kernels run. Output is numerically identical;
no effect on greedy decoding or the non-SDPA path.

## Results: RTX 3090, large-v3, `beam_size=5`, fp16

| Measurement | Baseline | This PR | Result |
|---|---|---|---|
| Cross-attn SDPA call (isolated) | 424 µs (math) | 87 µs (flash) | 4.9× faster |
| RTF with 120 s clip | 0.1349 | 0.1131 | −16% (1.19×) |
| RTF with LibriSpeech test-clean (200) | 0.1992 | 0.1674 | −16% (1.19×) |
| WER with LibriSpeech test-clean (200) | 2.070% | 2.070% | Δ 0.00% |

The gain scales with beam size, as expected. More beams mean more
cross-attention calls per step on the fallback path: no-op for greedy,
~1.19× at `beam_size=5` (default), ~1.50× at `beam_size=8`. Transcripts are
byte-identical at every beam size.

Transcripts are byte-identical across all 200 LibriSpeech test-clean samples
(token ids hash-identical), so WER is unchanged. Also verified identical on a
non-English clip (French, auto-detected) and confirmed no-op for greedy.
`tests/test_transcribe.py` passes for `large-v3`.