### PR TITLE
docs: fix 'a A100' to 'an A100' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ pip install setuptools-rust
 
 There are six model sizes, four with English-only versions, offering speed and accuracy tradeoffs.
 Below are the names of the available models and their approximate memory requirements and inference speed relative to the large model.
-The relative speeds below are measured by transcribing English speech on a A100, and the real-world speed may vary significantly depending on many factors including the language, the speaking speed, and the available hardware.
+The relative speeds below are measured by transcribing English speech on an A100, and the real-world speed may vary significantly depending on many factors including the language, the speaking speed, and the available hardware.
 
 |  Size  | Parameters | English-only model | Multilingual model | Required VRAM | Relative speed |
 |:------:|:----------:|:------------------:|:------------------:|:-------------:|:--------------:|


### PR DESCRIPTION
## Description

This PR fixes a grammar issue in `README.md` (line 62).

### Problem
Incorrect article: 'a A100' should be 'an A100' because 'A100' begins with a vowel sound.

### Before
```
measured by transcribing English speech on a A100
```

### After
```
measured by transcribing English speech on an A100
```