### PR TITLE
docs: fix redundant 'collected' in data/README.md

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -115,4 +115,4 @@ We downloaded the Common Voice Corpus 9 from [the official website](https://comm
 
 ### CoVOST 2
 
-We collected the `X into English` data collected using [the official repository](https://github.com/facebookresearch/covost).
+We collected the `X into English` data using [the official repository](https://github.com/facebookresearch/covost).


### PR DESCRIPTION
## Description

This PR fixes a grammar issue in `data/README.md` (line 118).

### Problem
The word 'collected' is used twice redundantly in the same sentence: 'We collected the ... data collected using ...'.

### Before
```
We collected the `X into English` data collected using [the official repository](https://github.com/facebookresearch/covost).
```

### After
```
We collected the `X into English` data using [the official repository](https://github.com/facebookresearch/covost).
```