### PR TITLE
docs: fix 'stage' to 'stages' (plural) in data/README.md

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -45,7 +45,7 @@ We downloaded the [CHiME-5 dataset](https://spandh.dcs.shef.ac.uk//chime_challen
 
 ### AMI-IHM, AMI-SDM1
 
-We preprocessed the [AMI Corpus](https://groups.inf.ed.ac.uk/ami/corpus/overview.shtml) by following the stage 0 and 2 of the [s5b recipe](https://github.com/kaldi-asr/kaldi/tree/master/egs/ami/s5b).
+We preprocessed the [AMI Corpus](https://groups.inf.ed.ac.uk/ami/corpus/overview.shtml) by following stages 0 and 2 of the [s5b recipe](https://github.com/kaldi-asr/kaldi/tree/master/egs/ami/s5b).
 
 
 ## Long-form English-only datasets


### PR DESCRIPTION
## Description

This PR fixes a grammar issue in `data/README.md` (line 48).

### Problem
'stage' should be 'stages' (plural) since two stages (0 and 2) are being referenced.

### Before
```
by following the stage 0 and 2 of the [s5b recipe](...)
```

### After
```
by following stages 0 and 2 of the [s5b recipe](...)
```