### PR TITLE
Fix: carry_initial_prompt overflows the decoder prompt budget

### DIFF
--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -1,5 +1,6 @@
 import os
 
+import numpy as np
 import pytest
 import torch
 
@@ -40,3 +41,67 @@ def test_transcribe(model_name: str):
                 timing_checked = True
 
     assert timing_checked
+
+
+def test_carry_initial_prompt_with_full_prompt_budget():
+    """A full-budget initial_prompt must be carried intact into later windows.
+
+    Regression test for `remaining_prompt_length == 0`: `tokens[-0:]` returns
+    the whole list, so the previous window's text used to be appended even
+    though the initial_prompt already fills the decoder prompt budget.
+    """
+    tokenizer = get_tokenizer(multilingual=False)
+    n_text_ctx = 448
+    prompt_budget = n_text_ctx // 2 - 1
+    initial_prompt = " ".join(["hello"] * prompt_budget)
+    initial_prompt_tokens = tokenizer.encode(" " + initial_prompt)
+    assert len(initial_prompt_tokens) == prompt_budget
+
+    window_text_tokens = tokenizer.encode(" some speech")
+    prompts = []
+
+    class FakeModel:
+        device = torch.device("cpu")
+        is_multilingual = False
+        num_languages = 99
+        dims = whisper.ModelDimensions(
+            n_mels=80,
+            n_audio_ctx=1500,
+            n_audio_state=1,
+            n_audio_head=1,
+            n_audio_layer=1,
+            n_vocab=tokenizer.encoding.n_vocab,
+            n_text_ctx=n_text_ctx,
+            n_text_state=1,
+            n_text_head=1,
+            n_text_layer=1,
+        )
+
+        def decode(self, mel, options):
+            prompts.append(list(options.prompt))
+            return whisper.DecodingResult(
+                audio_features=mel,
+                language="en",
+                tokens=[tokenizer.timestamp_begin]
+                + window_text_tokens
+                + [tokenizer.timestamp_begin + 1500],
+                temperature=0.0,
+                avg_logprob=0.0,
+                no_speech_prob=0.0,
+                compression_ratio=1.0,
+            )
+
+    # two 30-second windows of silence
+    audio = np.zeros(2 * whisper.audio.N_SAMPLES, dtype=np.float32)
+    whisper.transcribe(
+        FakeModel(),
+        audio,
+        initial_prompt=initial_prompt,
+        carry_initial_prompt=True,
+        fp16=False,
+    )
+
+    assert len(prompts) == 2
+    assert prompts[0] == initial_prompt_tokens
+    # the second window keeps the initial prompt and carries no previous text
+    assert prompts[1] == initial_prompt_tokens

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -239,7 +239,9 @@ def transcribe(
     if initial_prompt is not None:
         initial_prompt_tokens = tokenizer.encode(" " + initial_prompt.strip())
         all_tokens.extend(initial_prompt_tokens)
-        remaining_prompt_length -= len(initial_prompt_tokens)
+        remaining_prompt_length = max(
+            0, remaining_prompt_length - len(initial_prompt_tokens)
+        )
     else:
         initial_prompt_tokens = []
 
@@ -287,7 +289,14 @@ def transcribe(
 
             if carry_initial_prompt:
                 nignored = max(len(initial_prompt_tokens), prompt_reset_since)
-                remaining_prompt = all_tokens[nignored:][-remaining_prompt_length:]
+                # `initial_prompt` may already fill the decoder's prompt budget,
+                # leaving no room to carry previous text. `tokens[-0:]` returns the
+                # whole list rather than an empty one, so slice explicitly.
+                remaining_prompt = (
+                    all_tokens[nignored:][-remaining_prompt_length:]
+                    if remaining_prompt_length > 0
+                    else []
+                )
                 decode_options["prompt"] = initial_prompt_tokens + remaining_prompt
             else:
                 decode_options["prompt"] = all_tokens[prompt_reset_since:]


### PR DESCRIPTION
## Problem

`carry_initial_prompt=True` exists so that a long `initial_prompt` (a glossary, a
list of proper nouns) keeps reaching the decoder on every sliding window. When
the prompt is long enough to fill the decoder's prompt budget, it does the
opposite: from the second window onwards the `initial_prompt` is dropped
entirely and replaced by carried-over transcript.

## Root cause

The prompt budget is `n_text_ctx // 2 - 1`, which is 223 tokens for the released
checkpoints (`n_text_ctx = 448`). `remaining_prompt_length` tracks how much of
that budget is left once `initial_prompt` has taken its share:

```python
remaining_prompt_length = model.dims.n_text_ctx // 2 - 1
if initial_prompt is not None:
    initial_prompt_tokens = tokenizer.encode(" " + initial_prompt.strip())
    all_tokens.extend(initial_prompt_tokens)
    remaining_prompt_length -= len(initial_prompt_tokens)   # may reach 0 or go negative
```

```python
if carry_initial_prompt:
    nignored = max(len(initial_prompt_tokens), prompt_reset_since)
    remaining_prompt = all_tokens[nignored:][-remaining_prompt_length:]
    decode_options["prompt"] = initial_prompt_tokens + remaining_prompt
```

Once `initial_prompt` is 223 tokens or longer, `remaining_prompt_length` is zero
or negative and the slice inverts:

```python
>>> tokens = [1, 2, 3, 4, 5]
>>> tokens[-2:]     # room for 2 more tokens
[4, 5]
>>> tokens[-0:]     # no room left - returns everything
[1, 2, 3, 4, 5]
>>> tokens[-(-2):]  # negative - drops from the front instead
[3, 4, 5]
```

So instead of carrying nothing, the window carries the entire accumulated
transcript. `DecodingTask._get_initial_tokens` then trims the combined prompt
from the left:

```python
prompt_tokens[-(self.n_ctx // 2 - 1) :]
```

Left-trimming removes the leading tokens, which are exactly the
`initial_prompt` tokens the option is meant to preserve.

## Fix

Clamp the remaining length at zero, and slice explicitly so the empty case
stays empty.

## Evidence

`tiny.en` on CPU, `tests/jfk.flac` tiled to ~66 s (3 windows), `temperature=0`
and `condition_on_previous_text=True` so the carry-over path runs on every
window. `DecodingTask.__init__` was wrapped to record `options.prompt`.

**`initial_prompt` of exactly 223 tokens** (budget exactly full, so nothing may
be carried):

| window | prompt length | tokens over budget | `initial_prompt` reaches the decoder |
| --- | --- | --- | --- |
| 0 | 223 → 223 | 0 → 0 | yes → yes |
| 1 | 284 → 223 | 61 → 0 | **no → yes** |
| 2 | 367 → 223 | 144 → 0 | **no → yes** |

**`initial_prompt` of 14 tokens** (room to carry, i.e. every existing use of the
option):

| window | prompt length before | prompt length after |
| --- | --- | --- |
| 0 | 14 | 14 |
| 1 | 76 | 76 |
| 2 | 134 | 134 |

Per-window prompt token ids are identical before and after, and the transcript
is byte-identical (`sha256 861f8b56223f5e5124744caacf57f1f87dc4b37a10472cecf9a5ab6abf355bc5`
in both runs).

The repository's own workflow was run on this branch before opening the PR and
is green across the whole matrix, `pre-commit` included:
https://github.com/Yigtwxx/whisper/actions/runs/30698478749

## Compatibility

No API, CLI, or default behavior change. The only inputs affected are those
where `remaining_prompt_length` was already zero or negative, i.e. an
`initial_prompt` of at least `n_text_ctx // 2 - 1` tokens combined with
`carry_initial_prompt=True`. Every shorter prompt takes the same code path as
before and produces identical output.
