### PR TITLE
Add newer PyTorch versions to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,15 @@ jobs:
           - python-version: '3.13'
             pytorch-version: 2.5.1
             numpy-requirement: "'numpy'"
+          - python-version: '3.12'
+            pytorch-version: 2.6.0
+            numpy-requirement: "'numpy'"
+          - python-version: '3.13'
+            pytorch-version: 2.9.1
+            numpy-requirement: "'numpy'"
+          - python-version: '3.13'
+            pytorch-version: 2.13.0
+            numpy-requirement: "'numpy'"
     steps:
       - uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3
       - run: conda install -n test ffmpeg python=${{ matrix.python-version }}


### PR DESCRIPTION
## Problem

The test matrix stops at PyTorch 2.5.1, released in November 2024. PyTorch is
now at 2.13.0, so there is no CI coverage for any of the releases most users
actually install, including 2.6.0 — the release that changed the `torch.load`
default to `weights_only=True`.

## Change

Three rows added to `.github/workflows/test.yml`, spanning the gap:

| python | pytorch | why |
| --- | --- | --- |
| 3.12 | 2.6.0 | the `torch.load` `weights_only=True` default flip |
| 3.13 | 2.9.1 | mid-gap |
| 3.13 | 2.13.0 | current latest |

CPU wheels for all three combinations exist on `download.pytorch.org/whl/cpu`,
so the existing install line works unchanged.

Existing rows are untouched, the pinned action SHAs are untouched, and
`pyproject.toml` is untouched.

## Evidence

The full 12-row matrix was run on this branch before opening the PR:
https://github.com/Yigtwxx/whisper/actions/runs/30698476999

All 13 jobs pass, including the three added rows:

| job | result |
| --- | --- |
| `whisper-test (3.12, 2.6.0, 'numpy')` | success |
| `whisper-test (3.13, 2.9.1, 'numpy')` | success |
| `whisper-test (3.13, 2.13.0, 'numpy')` | success |

The nine pre-existing rows and `pre-commit` also pass unchanged, so nothing in
`whisper/` needs to change to support these releases.

## Note

This is deliberately limited to PyTorch versions. #2657 proposes the Python 3.14
row separately, so that is left out of scope here.
