### PR TITLE
Fix order of tensor operations in dtw_cpu call

### DIFF
--- a/whisper/timing.py
+++ b/whisper/timing.py
@@ -148,7 +148,7 @@ def dtw(x: torch.Tensor) -> np.ndarray:
                 "falling back to a slower DTW implementation..."
             )
 
-    return dtw_cpu(x.double().cpu().numpy())
+    return dtw_cpu(x.cpu().double().numpy())
 
 
 @dataclass


### PR DESCRIPTION
convert to f64 after moving to CPU. This will work on MPS device (apple m1)

original error:
```sh
    return dtw_cpu(x.double().cpu().numpy())
                   ~~~~~~~~^^
TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64. 
Please use float32 instead.
```