### PR TITLE
Fix suppress_tokens handling for iterables, None, and shared lists

### DIFF
--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+
+import pytest
+
+from whisper.decoding import DecodingOptions, DecodingTask
+from whisper.tokenizer import get_tokenizer
+
+
+def get_suppress_tokens(**kwargs):
+    tokenizer = get_tokenizer(multilingual=False)
+    task = SimpleNamespace(options=DecodingOptions(**kwargs), tokenizer=tokenizer)
+    return DecodingTask._get_suppress_tokens(task), tokenizer
+
+
+@pytest.mark.parametrize("value", [(5,), iter([5]), {5}])
+def test_suppress_tokens_accepts_any_iterable(value):
+    from_iterable, _ = get_suppress_tokens(suppress_tokens=value)
+    from_list, _ = get_suppress_tokens(suppress_tokens=[5])
+    assert from_iterable == from_list
+    assert 5 in from_iterable
+
+
+def test_suppress_tokens_does_not_mutate_the_options_list():
+    tokens = [5]
+    get_suppress_tokens(suppress_tokens=tokens)
+    assert tokens == [5]
+
+
+@pytest.mark.parametrize("value", [None, "", []])
+def test_suppress_tokens_empty_means_only_special_tokens(value):
+    suppress, tokenizer = get_suppress_tokens(suppress_tokens=value)
+    specials = {
+        tokenizer.transcribe,
+        tokenizer.translate,
+        tokenizer.sot,
+        tokenizer.sot_prev,
+        tokenizer.sot_lm,
+    }
+    if tokenizer.no_speech is not None:
+        specials.add(tokenizer.no_speech)
+    assert set(suppress) == specials
+
+
+def test_suppress_tokens_default_includes_non_speech_tokens():
+    suppress, tokenizer = get_suppress_tokens(suppress_tokens="-1")
+    assert set(tokenizer.non_speech_tokens) <= set(suppress)
+    assert -1 not in suppress

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -45,3 +45,11 @@ def test_suppress_tokens_default_includes_non_speech_tokens():
     suppress, tokenizer = get_suppress_tokens(suppress_tokens="-1")
     assert set(tokenizer.non_speech_tokens) <= set(suppress)
     assert -1 not in suppress
+
+
+@pytest.mark.parametrize("value", ["1,,2", ",1", "1,", "1,x"])
+def test_suppress_tokens_rejects_malformed_strings(value):
+    # only the empty string means "no tokens"; anything else is parsed
+    # strictly, so an empty or non-numeric component still raises
+    with pytest.raises(ValueError):
+        get_suppress_tokens(suppress_tokens=value)

--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -618,8 +618,11 @@ class DecodingTask:
         if suppress_tokens is None:
             suppress_tokens = []
         elif isinstance(suppress_tokens, str):
-            # interpret the empty string as an empty list
-            suppress_tokens = [int(t) for t in suppress_tokens.split(",") if t]
+            # interpret the empty string as an empty list; any other string is
+            # still parsed strictly, so a malformed value such as "1,,2" raises
+            suppress_tokens = (
+                [int(t) for t in suppress_tokens.split(",")] if suppress_tokens else []
+            )
         else:
             # accept any iterable of ints; copying also makes sure the
             # extend() calls below never modify the caller's list

--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -615,16 +615,19 @@ class DecodingTask:
     def _get_suppress_tokens(self) -> Tuple[int]:
         suppress_tokens = self.options.suppress_tokens
 
-        if isinstance(suppress_tokens, str):
-            suppress_tokens = [int(t) for t in suppress_tokens.split(",")]
+        if suppress_tokens is None:
+            suppress_tokens = []
+        elif isinstance(suppress_tokens, str):
+            # interpret the empty string as an empty list
+            suppress_tokens = [int(t) for t in suppress_tokens.split(",") if t]
+        else:
+            # accept any iterable of ints; copying also makes sure the
+            # extend() calls below never modify the caller's list
+            suppress_tokens = list(suppress_tokens)
 
         if -1 in suppress_tokens:
             suppress_tokens = [t for t in suppress_tokens if t >= 0]
             suppress_tokens.extend(self.tokenizer.non_speech_tokens)
-        elif suppress_tokens is None or len(suppress_tokens) == 0:
-            suppress_tokens = []  # interpret empty string as an empty list
-        else:
-            assert isinstance(suppress_tokens, list), "suppress_tokens must be a list"
 
         suppress_tokens.extend(
             [


### PR DESCRIPTION
`DecodingOptions.suppress_tokens` is typed as `Optional[Union[str, Iterable[int]]]`, but `_get_suppress_tokens` only actually handles two of those cases cleanly. Three problems, all in the same few lines:

1. Passing any iterable that isn't a list crashes. `suppress_tokens=(5,)` hits `assert isinstance(suppress_tokens, list)` and dies with an AssertionError, even though the annotation says any iterable of ints is fine. A tuple that happens to contain -1 sneaks through via a different branch, which makes the failure look random.

2. The `None` check is dead code. `if -1 in suppress_tokens` runs before the `elif suppress_tokens is None` branch, so an explicit `None` would raise `TypeError: argument of type 'NoneType' is not iterable` on the membership test before ever reaching the branch that's meant to handle it. It's currently masked by the truthiness guard at the call site, but the function can't actually handle the value its own signature advertises.

3. When a list without -1 is passed, the later `extend()` calls append the special tokens to the caller's list in place. Decode twice with the same options object and your suppress list quietly grows with sot/translate/transcribe ids each time.

The fix normalizes the input up front: `None` becomes an empty list, strings are parsed (an empty string now parses to an empty list instead of crashing on `int("")`, matching the comment that was already there), and anything else goes through `list()`, which both accepts arbitrary iterables and copies, so the caller's list is never touched. The -1 expansion and everything after it are unchanged, and the default `"-1"` path behaves exactly as before.

Added `tests/test_decoding.py` with unit tests for the tuple/iterator/set cases, the no-mutation guarantee, and the None/empty/default behaviors. They run without a model download. Before the fix, 6 of the 8 fail; after, all pass, along with the existing tokenizer tests. Also smoke-tested a real `transcribe()` of tests/jfk.flac with the tiny model on CPU: `suppress_tokens=(5,)` used to crash and now transcribes normally, and a passed-in list is unchanged after two runs.

black and isort clean on both files.
