### PR TITLE
Fix float64 audio mel filter dtype mismatch

### DIFF
--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -14,6 +14,8 @@ def test_audio():
 
     mel_from_audio = log_mel_spectrogram(audio)
     mel_from_file = log_mel_spectrogram(audio_path)
+    mel_from_float64 = log_mel_spectrogram(audio.astype(np.float64))
 
     assert np.allclose(mel_from_audio, mel_from_file)
+    assert np.allclose(mel_from_audio, mel_from_float64, rtol=1e-4, atol=1e-4)
     assert mel_from_audio.max() - mel_from_audio.min() <= 2.0

--- a/whisper/audio.py
+++ b/whisper/audio.py
@@ -148,7 +148,7 @@ def log_mel_spectrogram(
     stft = torch.stft(audio, N_FFT, HOP_LENGTH, window=window, return_complex=True)
     magnitudes = stft[..., :-1].abs() ** 2
 
-    filters = mel_filters(audio.device, n_mels)
+    filters = mel_filters(audio.device, n_mels).to(dtype=magnitudes.dtype)
     mel_spec = filters @ magnitudes
 
     log_spec = torch.clamp(mel_spec, min=1e-10).log10()


### PR DESCRIPTION
## Summary

`log_mel_spectrogram()` accepts NumPy arrays and tensors, but its cached Mel filters were always `float32`. A `float64` waveform therefore produced a matrix multiplication dtype error instead of a spectrogram.

This converts the filter bank to the STFT magnitude dtype before projection. Existing `float16` and `float32` behavior is unchanged, while double-precision waveforms now produce finite Mel spectrograms. The regression test uses the repository's JFK audio and compares the `float64` result with the existing `float32` path.

Before:

```text
RuntimeError: expected m1 and m2 to have the same dtype, but got: float != double
```

After:

```text
dtype=torch.float64 shape=(80, 1100) finite=True
max_abs_difference=0.00001254
```

## Testing

- `pytest --durations=0 -q -k 'not test_transcribe or test_transcribe[tiny] or test_transcribe[tiny.en]' -m 'not requires_cuda'` (19 passed)
- `pre-commit run --all-files`
