### PR TITLE
Fix: Remove stray </span> from 'archaeology' spelling normalization

### DIFF
--- a/whisper/normalizers/english.json
+++ b/whisper/normalizers/english.json
@@ -86,7 +86,7 @@
     "archaeologically": "archeologically",
     "archaeologist": "archeologist",
     "archaeologists": "archeologists",
-    "archaeology": "archeology</span>",
+    "archaeology": "archeology",
     "ardour": "ardor",
     "armour": "armor",
     "armoured": "armored",


### PR DESCRIPTION
## What
`whisper/normalizers/english.json` maps the British spelling "archaeology"
to `"archeology</span>"` . The value contains a stray HTML closing tag.

## Where
Line 89:

```json
"archaeology": "archeology</span>",
```

This file is the dictionary used by `EnglishSpellingNormalizer` (keys =
British spelling, values = American replacement). Because of the artifact,
normalizing any text containing "archaeology" currently produces
`archeology</span>`, injecting a literal `</span>` into the output. This
affects normalized transcripts and any WER evaluation over text with that word.

Present since the initial commit (6e3be77, Sep 2022), so this affects all released versions.

## Fix
Remove the trailing `</span>` so the value is just `"archeology"`.

## Verification
- `python -c "import json; json.load(open('whisper/normalizers/english.json'))"` passes (valid JSON).
- Diff is a single-line change touching only this entry.