### PR TITLE
Only rewrite a standalone 1 as "one" in the English number normalizer

### DIFF
--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -42,13 +42,16 @@ def test_number_normalizer(std):
     assert std("3.14") == "3.14"
     assert std("3 point 2") == "3.2"
     assert std("3 point 14") == "3.14"
+    assert std("3 point 1") == "3.1"
     assert std("fourteen point 4") == "14.4"
+    assert std("one point five") == "1.5"
     assert std("two point two five dollars") == "$2.25"
     assert std("two hundred million dollars") == "$200000000"
     assert std("$20.1 million") == "$20100000"
 
     assert std("ninety percent") == "90%"
     assert std("seventy six per cent") == "76%"
+    assert std("one percent") == "1%"
 
     assert std("double oh seven") == "007"
     assert std("double zero seven") == "007"
@@ -61,17 +64,22 @@ def test_number_normalizer(std):
 
     assert std("minus 500") == "-500"
     assert std("positive twenty thousand") == "+20000"
+    assert std("minus one") == "-1"
 
     assert std("two dollars and seventy cents") == "$2.70"
     assert std("3 cents") == "¢3"
     assert std("$0.36") == "¢36"
     assert std("three euros and sixty five cents") == "€3.65"
+    assert std("one dollar and one cent") == "$1.01"
 
     assert std("three and a half million") == "3500000"
     assert std("forty eight and a half dollars") == "$48.5"
     assert std("b747") == "b 747"
     assert std("10 th") == "10th"
     assert std("10th") == "10th"
+
+    assert std("one") == "one"
+    assert std("ones") == "ones"
 
 
 def test_spelling_normalizer():

--- a/whisper/normalizers/english.py
+++ b/whisper/normalizers/english.py
@@ -434,8 +434,10 @@ class EnglishNumberNormalizer:
         s = re.sub(r"([€£$])([0-9]+) (?:and )?¢([0-9]{1,2})\b", combine_cents, s)
         s = re.sub(r"[€£$]0.([0-9]{1,2})\b", extract_cents, s)
 
-        # write "one(s)" instead of "1(s)", just for the readability
-        s = re.sub(r"\b1(s?)\b", r"one\1", s)
+        # write "one(s)" instead of "1(s)", just for the readability;
+        # only when it stands alone, since `\b` would also match inside
+        # numbers like "$1", "1%", "1.5" and "3.1"
+        s = re.sub(r"(?<!\S)1(s?)(?!\S)", r"one\1", s)
 
         return s
 


### PR DESCRIPTION
`EnglishNumberNormalizer.postprocess` spells the digit 1 back out with `re.sub(r"\b1(s?)\b", r"one\1", s)`. `\b` also matches next to `.`, `$`, `¢`, `€`, `£`, `%` and `-`, so the rule fires inside numbers as well:

| input | before | after |
| --- | --- | --- |
| `three point one` | `3 one` | `3.1` |
| `one point five` | `one.5` | `1.5` |
| `one dollar` | ` one` | `$1` |
| `one percent` | `one ` | `1%` |
| `minus one` | `-one` | `-1` |

The existing tests already pin the shape for the values on either side: `"3 point 2" -> "3.2"`, `"3 cents" -> "¢3"`, `"ninety percent" -> "90%"`, `"minus 500" -> "-500"`. Only the value one came out different, so `one dollar` and `one` normalize to the same string and WER scores them as a match.

Requiring whitespace on both sides keeps the readability rule for a lone `1` or `1s` and leaves everything else alone. On this repo's own README, "PyTorch 1.10.1" was normalizing to "one.10 one" and "Appendix D.1" to "d one". Seven asserts added, existing tests unchanged and passing.