### PR TITLE
fix: 0秒の初期タイムスタンプ制限を有効化

### DIFF
--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+
+import torch
+
+from whisper.decoding import ApplyTimestampRules, DecodingOptions, DecodingTask
+
+
+def test_zero_max_initial_timestamp():
+    model = SimpleNamespace(
+        is_multilingual=False,
+        num_languages=99,
+        dims=SimpleNamespace(n_text_ctx=448, n_audio_ctx=1500),
+        decoder=SimpleNamespace(blocks=[]),
+    )
+    task = DecodingTask(model, DecodingOptions(max_initial_timestamp=0.0))
+    timestamp_rules = next(
+        rule for rule in task.logit_filters if isinstance(rule, ApplyTimestampRules)
+    )
+
+    logits = torch.zeros(1, task.tokenizer.encoding.n_vocab)
+    tokens = torch.tensor([task.initial_tokens])
+    timestamp_rules.apply(logits, tokens)
+
+    assert torch.isfinite(logits[0, task.tokenizer.timestamp_begin])
+    assert torch.isneginf(logits[0, task.tokenizer.timestamp_begin + 1 :]).all()

--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -559,7 +559,7 @@ class DecodingTask:
         if not options.without_timestamps:
             precision = CHUNK_LENGTH / model.dims.n_audio_ctx  # usually 0.02 seconds
             max_initial_timestamp_index = None
-            if options.max_initial_timestamp:
+            if options.max_initial_timestamp is not None:
                 max_initial_timestamp_index = round(
                     self.options.max_initial_timestamp / precision
                 )


### PR DESCRIPTION
## 概要

`DecodingOptions(max_initial_timestamp=0.0)` が、最初のタイムスタンプを0秒に制限するよう修正します。

## 背景

`max_initial_timestamp` は `Optional[float]` ですが、従来は真偽値で判定されていたため、`0.0` が `None` と同じ扱いになっていました。その結果、0秒を指定すると上限が無効になり、0秒より後の初期タイムスタンプも選択可能でした。

## 変更内容

- `None` の場合だけ初期タイムスタンプ上限を無効化
- `0.0` を有効な上限として扱う回帰テストを追加
- 0.00秒より後のタイムスタンプlogitが抑制されることを確認

## テスト

- `.venv/bin/python -m pytest -q tests/test_decoding.py`
- `.venv/bin/python -m pytest -q -m 'not requires_cuda' -k 'not test_transcribe'`
- Black、isort、flake8（変更ファイル）
