### PR TITLE
fix: 空のデコード候補のゼロ除算を防止

### DIFF
--- a/tests/test_decoding_ranker.py
+++ b/tests/test_decoding_ranker.py
@@ -1,0 +1,11 @@
+import torch
+
+from whisper.decoding import MaximumLikelihoodRanker
+
+
+def test_maximum_likelihood_ranker_accepts_empty_sequence():
+    ranker = MaximumLikelihoodRanker(length_penalty=None)
+    tokens = [[torch.empty(0, dtype=torch.long), torch.tensor([1])]]
+    sum_logprobs = [[-0.1, -0.2]]
+
+    assert ranker.rank(tokens, sum_logprobs) == [0]

--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -201,7 +201,8 @@ class MaximumLikelihoodRanker(SequenceRanker):
             result = []
             for logprob, length in zip(logprobs, lengths):
                 if self.length_penalty is None:
-                    penalty = length
+                    # A blank output has no text tokens, but its score includes EOT.
+                    penalty = max(length, 1)
                 else:
                     # from the Google NMT paper
                     penalty = ((5 + length) / 6) ** self.length_penalty


### PR DESCRIPTION
## 概要

空のデコード候補をMaximum Likelihood Rankerで評価した際のゼロ除算を防ぎます。

## 背景

`suppress_blank=False` かつ `without_timestamps=True` のデコードで、モデルが最初にEOTを選ぶと、候補にテキストtokenが含まれません。従来の単純な長さ正規化は候補長をそのまま除数にしていたため、有効な空出力に対して `ZeroDivisionError` が発生していました。

## 変更内容

- 単純な長さ正規化の除数を最小1に制限
- 非空候補のランキング動作は維持
- 空候補と非空候補を同時に評価する回帰テストを追加

空候補にもスコアへ含まれるEOTがあるため、除数1として評価します。

## テスト

- `.venv/bin/python -m pytest -q tests/test_decoding_ranker.py`
- `.venv/bin/python -m pytest -q -m 'not requires_cuda' -k 'not test_transcribe'`
- `suppress_blank=False` で最初にEOTを返すデコード経路の再現確認
- Black、isort、flake8（変更ファイル）
