### PR TITLE
Fix grouped decoding for audio batches

### DIFF
--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -1,0 +1,110 @@
+import pytest
+import torch
+
+from whisper.decoding import DecodingOptions
+from whisper.model import ModelDimensions, Whisper
+
+
+@pytest.fixture
+def model() -> Whisper:
+    torch.manual_seed(0)
+    dimensions = ModelDimensions(
+        n_mels=80,
+        n_audio_ctx=2,
+        n_audio_state=4,
+        n_audio_head=1,
+        n_audio_layer=1,
+        n_vocab=51864,
+        n_text_ctx=8,
+        n_text_state=4,
+        n_text_head=1,
+        n_text_layer=1,
+    )
+    model = Whisper(dimensions).eval()
+    for parameter in model.parameters():
+        torch.nn.init.normal_(parameter, mean=0.0, std=0.02)
+    return model
+
+
+@pytest.fixture
+def audio_features() -> torch.Tensor:
+    torch.manual_seed(1)
+    return torch.randn(2, 2, 4)
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        DecodingOptions(
+            language="en",
+            beam_size=2,
+            sample_len=1,
+            without_timestamps=True,
+            fp16=False,
+        ),
+        DecodingOptions(
+            language="en",
+            temperature=1.0,
+            best_of=2,
+            sample_len=1,
+            without_timestamps=True,
+            fp16=False,
+        ),
+    ],
+    ids=["beam-search", "best-of"],
+)
+def test_grouped_decoding_accepts_multiple_audio_inputs(
+    model: Whisper, audio_features: torch.Tensor, options: DecodingOptions
+) -> None:
+    torch.manual_seed(2)
+
+    results = model.decode(audio_features, options)
+
+    assert isinstance(results, list)
+    assert len(results) == len(audio_features)
+    for result, expected_features in zip(results, audio_features):
+        torch.testing.assert_close(result.audio_features, expected_features)
+
+
+def test_batched_beam_search_matches_independent_decodes(
+    model: Whisper, audio_features: torch.Tensor
+) -> None:
+    options = DecodingOptions(
+        language="en",
+        beam_size=2,
+        sample_len=1,
+        without_timestamps=True,
+        fp16=False,
+    )
+
+    batched = model.decode(audio_features, options)
+    independent = [model.decode(features, options) for features in audio_features]
+
+    assert isinstance(batched, list)
+    assert [result.tokens for result in batched] == [
+        result.tokens for result in independent
+    ]
+
+
+def test_single_audio_beam_search_does_not_duplicate_audio_features(
+    model: Whisper, audio_features: torch.Tensor
+) -> None:
+    observed_batch_sizes = []
+    key_projection = model.decoder.blocks[0].cross_attn.key
+    handle = key_projection.register_forward_pre_hook(
+        lambda _module, inputs: observed_batch_sizes.append(inputs[0].shape[0])
+    )
+    options = DecodingOptions(
+        language="en",
+        beam_size=2,
+        sample_len=1,
+        without_timestamps=True,
+        fp16=False,
+    )
+
+    try:
+        model.decode(audio_features[0], options)
+    finally:
+        handle.remove()
+
+    assert observed_batch_sizes == [1]

--- a/whisper/decoding.py
+++ b/whisper/decoding.py
@@ -730,6 +730,11 @@ class DecodingTask:
                 )
             ]
 
+        # A single audio input broadcasts across its groups. Batched inputs need
+        # one audio feature tensor per group to preserve the audio-token pairing.
+        if n_audio > 1 and self.n_group > 1:
+            audio_features = audio_features.repeat_interleave(self.n_group, dim=0)
+
         # repeat text tensors by the group size, for beam search or best-of-n sampling
         tokens = tokens.repeat_interleave(self.n_group, dim=0).to(audio_features.device)
 


### PR DESCRIPTION
## Summary

- repeat encoded audio features for each beam or sampled group when decoding more than one audio input;
- keep the existing single-audio broadcast path unchanged;
- add deterministic beam-search, best-of, pairing, and single-audio regression tests.

## Problem

`DecodingTask.run()` expands the token batch by `n_group`, but it does not expand a multi-audio feature batch. Beam search and best-of decoding can therefore pass different batch sizes to the decoder, or lose the intended audio-to-token pairing.

This change adds one feature row per group only when both `n_audio > 1` and `n_group > 1`. A single audio input still uses Whisper's existing broadcast behavior.

This addresses the failure reported in [discussion #2659](https://github.com/openai/whisper/discussions/2659).

## Validation

- the new tests fail on current `main` for grouped multi-audio decoding;
- all four new tests pass with this change;
- the existing CPU test subset passes (21 tests).

The tests use a small deterministic model. They do not download a checkpoint.
