### PR TITLE
Remove alignment hooks after inference errors

### DIFF
--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,9 +1,12 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import numpy as np
 import pytest
 import scipy.ndimage
 import torch
 
-from whisper.timing import dtw_cpu, dtw_cuda, median_filter
+from whisper.timing import dtw_cpu, dtw_cuda, find_alignment, median_filter
 
 sizes = [
     (10, 20),
@@ -17,6 +20,34 @@ shapes = [
     (4, 5, 345),
     (6, 12, 240, 512),
 ]
+
+
+def test_find_alignment_removes_hooks_after_model_failure():
+    handles = [Mock(), Mock()]
+    blocks = [
+        SimpleNamespace(
+            cross_attn=SimpleNamespace(register_forward_hook=Mock(return_value=handle))
+        )
+        for handle in handles
+    ]
+    model = Mock()
+    model.dims = SimpleNamespace(n_text_layer=len(blocks))
+    model.decoder = SimpleNamespace(blocks=blocks)
+    model.device = "cpu"
+    model.side_effect = RuntimeError("decoder failed")
+    tokenizer = SimpleNamespace(sot_sequence=(1,), no_timestamps=2, eot=3)
+
+    with pytest.raises(RuntimeError, match="decoder failed"):
+        find_alignment(
+            model,
+            tokenizer,
+            text_tokens=[4],
+            mel=torch.zeros(80, 2),
+            num_frames=2,
+        )
+
+    for handle in handles:
+        handle.remove.assert_called_once_with()
 
 
 @pytest.mark.parametrize("N, M", sizes)

--- a/whisper/timing.py
+++ b/whisper/timing.py
@@ -193,15 +193,16 @@ def find_alignment(
 
     from .model import disable_sdpa
 
-    with torch.no_grad(), disable_sdpa():
-        logits = model(mel.unsqueeze(0), tokens.unsqueeze(0))[0]
-        sampled_logits = logits[len(tokenizer.sot_sequence) :, : tokenizer.eot]
-        token_probs = sampled_logits.softmax(dim=-1)
-        text_token_probs = token_probs[np.arange(len(text_tokens)), text_tokens]
-        text_token_probs = text_token_probs.tolist()
-
-    for hook in hooks:
-        hook.remove()
+    try:
+        with torch.no_grad(), disable_sdpa():
+            logits = model(mel.unsqueeze(0), tokens.unsqueeze(0))[0]
+            sampled_logits = logits[len(tokenizer.sot_sequence) :, : tokenizer.eot]
+            token_probs = sampled_logits.softmax(dim=-1)
+            text_token_probs = token_probs[np.arange(len(text_tokens)), text_tokens]
+            text_token_probs = text_token_probs.tolist()
+    finally:
+        for hook in hooks:
+            hook.remove()
 
     # heads * tokens * frames
     weights = torch.stack([QKs[_l][_h] for _l, _h in model.alignment_heads.indices().T])


### PR DESCRIPTION
## Summary

- Remove word-alignment forward hooks in a `finally` block.
- Add a regression test for the decoder failure path.

## Problem

`find_alignment` installs forward hooks before it calls the model. If the model raises, the current cleanup is skipped. The hooks remain installed and retain their captured activation state. Later calls can add more hooks and collect duplicate activations.

## Change

The existing hook removal now runs for both success and error paths. The successful inference path is unchanged. The regression test raises from the model and requires each hook handle to be removed once.

## Validation

- `python -m pytest tests/test_timing.py -q -m "not requires_cuda"` — 9 passed, 8 deselected.
- `python -m pytest tests/test_transcribe.py::test_transcribe[tiny.en] tests/test_timing.py -q -m "not requires_cuda"` — 10 passed, 8 deselected.
- Black and isort checks pass for both changed files.