### PR TITLE
Make SDPA disable scopes thread-local

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,166 @@
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import torch
+
+import whisper.model as model_module
+from whisper.model import MultiHeadAttention, disable_sdpa
+
+
+def make_attention_inputs():
+    return tuple(torch.randn(1, 2, 4) for _ in range(3))
+
+
+def uses_sdpa(attention, inputs):
+    _, weights = attention.qkv_attention(*inputs)
+    return weights is None
+
+
+@pytest.fixture
+def sdpa_probe(monkeypatch):
+    calls = []
+
+    def scaled_dot_product_attention(query, key, value, *, is_causal):
+        del key, value, is_causal
+        calls.append(threading.get_ident())
+        return query
+
+    monkeypatch.setattr(model_module, "SDPA_AVAILABLE", True)
+    monkeypatch.setattr(
+        model_module,
+        "scaled_dot_product_attention",
+        scaled_dot_product_attention,
+    )
+    monkeypatch.setattr(MultiHeadAttention, "use_sdpa", True)
+    return calls
+
+
+def test_disable_sdpa_does_not_affect_another_thread(sdpa_probe):
+    disabled_attention = MultiHeadAttention(4, 1)
+    enabled_attention = MultiHeadAttention(4, 1)
+    inputs = make_attention_inputs()
+    disabled_context_ready = threading.Event()
+    enabled_context_done = threading.Event()
+
+    def run_disabled():
+        with disable_sdpa():
+            disabled_context_ready.set()
+            if not enabled_context_done.wait(timeout=10):
+                raise TimeoutError("enabled context did not finish")
+            return threading.get_ident(), uses_sdpa(disabled_attention, inputs)
+
+    def run_enabled():
+        if not disabled_context_ready.wait(timeout=10):
+            raise TimeoutError("disabled context did not start")
+        try:
+            return threading.get_ident(), uses_sdpa(enabled_attention, inputs)
+        finally:
+            enabled_context_done.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        disabled = executor.submit(run_disabled)
+        enabled = executor.submit(run_enabled)
+        disabled_thread, disabled_result = disabled.result(timeout=15)
+        enabled_thread, enabled_result = enabled.result(timeout=15)
+
+    assert disabled_thread != enabled_thread
+    assert disabled_result is False
+    assert enabled_result is True
+    assert sdpa_probe == [enabled_thread]
+
+
+def test_overlapping_disable_sdpa_contexts_restore_independently(sdpa_probe):
+    first_attention = MultiHeadAttention(4, 1)
+    second_attention = MultiHeadAttention(4, 1)
+    unrelated_attention = MultiHeadAttention(4, 1)
+    inputs = make_attention_inputs()
+    contexts_ready = threading.Barrier(3)
+    allow_first_exit = threading.Event()
+    first_exited = threading.Event()
+    second_checked = threading.Event()
+    allow_second_exit = threading.Event()
+
+    def run_first():
+        try:
+            with disable_sdpa():
+                contexts_ready.wait(timeout=10)
+                if not allow_first_exit.wait(timeout=10):
+                    raise TimeoutError("first context was not released")
+                return threading.get_ident(), uses_sdpa(first_attention, inputs)
+        finally:
+            first_exited.set()
+
+    def run_second():
+        with disable_sdpa():
+            contexts_ready.wait(timeout=10)
+            if not first_exited.wait(timeout=10):
+                raise TimeoutError("first context did not exit")
+            result = threading.get_ident(), uses_sdpa(second_attention, inputs)
+            second_checked.set()
+            if not allow_second_exit.wait(timeout=10):
+                raise TimeoutError("second context was not released")
+            return result
+
+    main_thread = threading.get_ident()
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(run_first)
+        second = executor.submit(run_second)
+        try:
+            contexts_ready.wait(timeout=10)
+            assert uses_sdpa(unrelated_attention, inputs) is True
+            allow_first_exit.set()
+            first_thread, first_result = first.result(timeout=15)
+            if not second_checked.wait(timeout=10):
+                raise TimeoutError("second context did not observe the first exit")
+            assert uses_sdpa(unrelated_attention, inputs) is True
+        finally:
+            allow_first_exit.set()
+            allow_second_exit.set()
+
+        second_thread, second_result = second.result(timeout=15)
+
+    assert first_thread != second_thread
+    assert first_result is False
+    assert second_result is False
+    assert sdpa_probe == [main_thread, main_thread]
+
+
+def test_disable_sdpa_supports_nested_contexts(sdpa_probe):
+    attention = MultiHeadAttention(4, 1)
+    inputs = make_attention_inputs()
+
+    assert uses_sdpa(attention, inputs) is True
+    with disable_sdpa():
+        assert uses_sdpa(attention, inputs) is False
+        with disable_sdpa():
+            assert uses_sdpa(attention, inputs) is False
+        assert uses_sdpa(attention, inputs) is False
+    assert uses_sdpa(attention, inputs) is True
+
+    assert len(sdpa_probe) == 2
+
+
+def test_disable_sdpa_restores_context_after_an_exception(sdpa_probe):
+    attention = MultiHeadAttention(4, 1)
+    inputs = make_attention_inputs()
+
+    with pytest.raises(RuntimeError, match="failed inside context"):
+        with disable_sdpa():
+            assert uses_sdpa(attention, inputs) is False
+            raise RuntimeError("failed inside context")
+
+    assert uses_sdpa(attention, inputs) is True
+    assert len(sdpa_probe) == 1
+
+
+def test_manual_global_sdpa_disable_is_preserved(sdpa_probe, monkeypatch):
+    attention = MultiHeadAttention(4, 1)
+    inputs = make_attention_inputs()
+    monkeypatch.setattr(MultiHeadAttention, "use_sdpa", False)
+
+    assert uses_sdpa(attention, inputs) is False
+    with disable_sdpa():
+        assert uses_sdpa(attention, inputs) is False
+    assert uses_sdpa(attention, inputs) is False
+    assert sdpa_probe == []

--- a/whisper/model.py
+++ b/whisper/model.py
@@ -2,6 +2,7 @@ import base64
 import gzip
 from contextlib import contextmanager
 from dataclasses import dataclass
+from threading import local
 from typing import Dict, Iterable, Optional, Tuple
 
 import numpy as np
@@ -20,6 +21,9 @@ try:
 except (ImportError, RuntimeError, OSError):
     scaled_dot_product_attention = None
     SDPA_AVAILABLE = False
+
+
+_sdpa_state = local()
 
 
 @dataclass
@@ -70,12 +74,15 @@ def sinusoids(length, channels, max_timescale=10000):
 
 @contextmanager
 def disable_sdpa():
-    prev_state = MultiHeadAttention.use_sdpa
+    previous_depth = getattr(_sdpa_state, "disable_depth", 0)
+    _sdpa_state.disable_depth = previous_depth + 1
     try:
-        MultiHeadAttention.use_sdpa = False
         yield
     finally:
-        MultiHeadAttention.use_sdpa = prev_state
+        if previous_depth == 0:
+            del _sdpa_state.disable_depth
+        else:
+            _sdpa_state.disable_depth = previous_depth
 
 
 class MultiHeadAttention(nn.Module):
@@ -120,7 +127,11 @@ class MultiHeadAttention(nn.Module):
         k = k.view(*k.shape[:2], self.n_head, -1).permute(0, 2, 1, 3)
         v = v.view(*v.shape[:2], self.n_head, -1).permute(0, 2, 1, 3)
 
-        if SDPA_AVAILABLE and MultiHeadAttention.use_sdpa:
+        if (
+            SDPA_AVAILABLE
+            and MultiHeadAttention.use_sdpa
+            and getattr(_sdpa_state, "disable_depth", 0) == 0
+        ):
             if k.shape[0] == 1 and q.shape[0] != 1:
                 # Cross-attention K/V have batch 1 and broadcast against the
                 # beam-expanded query; the fused SDPA kernels reject the batch


### PR DESCRIPTION
## Problem

`find_alignment()` enters `disable_sdpa()` because word alignment needs
attention weights. `disable_sdpa()` currently changes
`MultiHeadAttention.use_sdpa`, a class attribute shared by every attention
instance in the process.

This creates cross-thread interference even when workers use different model
instances:

- an unrelated worker uses the non-SDPA attention path while alignment is in
  progress;
- if two disable scopes overlap, one scope can restore the class attribute
  while the other scope still needs attention weights.

## Change

Track the nested disable depth in thread-local state. `qkv_attention()` now
checks the calling thread's depth together with the existing `SDPA_AVAILABLE`
and `MultiHeadAttention.use_sdpa` controls.

`MultiHeadAttention.use_sdpa` remains the process-wide opt-out. Nested scopes
and exception restoration keep their existing behavior. No function signature
or checkpoint key changes.

## Validation

- The five focused tests cover an unrelated thread, overlapping scopes,
  nested scopes, exception restoration, and the process-wide opt-out.
- The focused tests fail twice on current `main` and all five pass with this
  change.
- The repository's CPU CI selection passes: 24 passed, 20 deselected.
- Black, isort, the repository's flake8 configuration, and `git diff --check`
  pass.
- A small attention module was also exercised with
  `torch.compile(fullgraph=True, backend="eager")` and `torch.export` with the
  scope enabled, disabled, and restored on PyTorch 2.6 CPU.

## Scope

This change isolates SDPA selection between operating-system threads. It does
not make concurrent calls on one Whisper model safe: word-alignment hooks and
KV-cache state are separate shared-model concerns. It does not provide
coroutine-local isolation. CUDA behavior was not tested, and this change makes
no CUDA, kernel-concurrency, or throughput claim.
