### PR TITLE
Keep each transcript segment on one TSV row

### DIFF
--- a/tests/test_tsv_writer.py
+++ b/tests/test_tsv_writer.py
@@ -17,4 +17,4 @@ def test_tsv_keeps_segment_text_in_one_row(text):
     assert len(rows) == 2
     assert rows[0] == "start\tend\ttext"
     assert rows[1].split("\t")[:2] == ["0", "1250"]
-    assert rows[1].split("\t")[2].split() == ["first", "second"]
+    assert rows[1].split("\t")[2] == "first second"

--- a/tests/test_tsv_writer.py
+++ b/tests/test_tsv_writer.py
@@ -1,0 +1,20 @@
+import io
+
+import pytest
+
+from whisper.utils import WriteTSV
+
+
+@pytest.mark.parametrize(
+    "text", ["first\nsecond", "first\rsecond", "first\r\nsecond", "first\tsecond"]
+)
+def test_tsv_keeps_segment_text_in_one_row(text):
+    output = io.StringIO()
+    WriteTSV(".").write_result(
+        {"segments": [{"start": 0.0, "end": 1.25, "text": text}]}, output
+    )
+    rows = output.getvalue().splitlines()
+    assert len(rows) == 2
+    assert rows[0] == "start\tend\ttext"
+    assert rows[1].split("\t")[:2] == ["0", "1250"]
+    assert rows[1].split("\t")[2].split() == ["first", "second"]

--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -281,7 +281,15 @@ class WriteTSV(ResultWriter):
         for segment in result["segments"]:
             print(round(1000 * segment["start"]), file=file, end="\t")
             print(round(1000 * segment["end"]), file=file, end="\t")
-            print(segment["text"].strip().replace("\t", " "), file=file, flush=True)
+            print(
+                segment["text"]
+                .strip()
+                .replace("\t", " ")
+                .replace("\r", " ")
+                .replace("\n", " "),
+                file=file,
+                flush=True,
+            )
 
 
 class WriteJSON(ResultWriter):

--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -285,6 +285,7 @@ class WriteTSV(ResultWriter):
                 segment["text"]
                 .strip()
                 .replace("\t", " ")
+                .replace("\r\n", " ")
                 .replace("\r", " ")
                 .replace("\n", " "),
                 file=file,


### PR DESCRIPTION
Embedded newlines in segment text create extra rows in TSV output without timestamps. Replace carriage returns and newlines with spaces, as the writer already does for tabs.

Adds coverage for LF, CR, CRLF, and tab characters.
