### PR TITLE
Escape timestamp arrows in word-level subtitles

### DIFF
--- a/tests/test_subtitle_arrows.py
+++ b/tests/test_subtitle_arrows.py
@@ -1,0 +1,17 @@
+import pytest
+
+from whisper.utils import WriteSRT, WriteVTT
+
+
+@pytest.mark.parametrize("writer_class", [WriteVTT, WriteSRT])
+@pytest.mark.parametrize("highlight", [False, True])
+def test_word_subtitles_escape_timestamp_arrows(writer_class, highlight):
+    word = {"word": " left --> right", "start": 0.0, "end": 1.0}
+    result = {
+        "segments": [{"start": 0.0, "end": 1.0, "text": word["word"], "words": [word]}]
+    }
+    cues = list(writer_class(".").iterate_result(result, highlight_words=highlight))
+    assert cues
+    assert all("-->" not in text for _, _, text in cues)
+    assert "left -> right" in cues[0][2]
+    assert word["word"] == " left --> right"

--- a/tests/test_subtitle_arrows.py
+++ b/tests/test_subtitle_arrows.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import pytest
 
 from whisper.utils import WriteSRT, WriteVTT
@@ -10,8 +12,15 @@ def test_word_subtitles_escape_timestamp_arrows(writer_class, highlight):
     result = {
         "segments": [{"start": 0.0, "end": 1.0, "text": word["word"], "words": [word]}]
     }
+    original = deepcopy(result)
     cues = list(writer_class(".").iterate_result(result, highlight_words=highlight))
     assert cues
     assert all("-->" not in text for _, _, text in cues)
     assert "left -> right" in cues[0][2]
-    assert word["word"] == " left --> right"
+    assert result == original
+    expected_times = (
+        ("00:00.000", "00:01.000")
+        if writer_class is WriteVTT
+        else ("00:00:00,000", "00:00:01,000")
+    )
+    assert cues[0][:2] == expected_times

--- a/whisper/utils.py
+++ b/whisper/utils.py
@@ -156,6 +156,7 @@ class SubtitlesWriter(ResultWriter):
                         segment["words"][chunk_index : chunk_index + words_count]
                     ):
                         timing = original_timing.copy()
+                        timing["word"] = timing["word"].replace("-->", "->")
                         long_pause = (
                             not preserve_segments and timing["start"] - last > 3.0
                         )


### PR DESCRIPTION
Segment-level subtitles already replace `-->` in transcript text, but word-level subtitles leave it intact. Apply the same escaping before assembling word-level cues, including highlighted words.

Adds SRT and VTT regressions and checks that the input timings remain unchanged.
