### PR TITLE
Detect language from the first requested audio clip

### DIFF
--- a/tests/test_language_detection.py
+++ b/tests/test_language_detection.py
@@ -1,0 +1,121 @@
+import importlib
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from whisper.audio import N_FRAMES, pad_or_trim
+from whisper.decoding import DecodingResult
+
+transcribe_module = importlib.import_module("whisper.transcribe")
+
+
+@pytest.fixture
+def make_transcription(monkeypatch):
+    def make(content_frames=6000):
+        # Frame indices expose which part of the input reaches language detection.
+        mel = torch.arange(content_frames + N_FRAMES, dtype=torch.float32)
+        mel = mel.unsqueeze(0).expand(80, -1)
+        monkeypatch.setattr(
+            transcribe_module, "log_mel_spectrogram", Mock(return_value=mel)
+        )
+        model = SimpleNamespace(
+            device=torch.device("cpu"),
+            dims=SimpleNamespace(n_mels=80, n_audio_ctx=1500, n_text_ctx=448),
+            is_multilingual=True,
+            num_languages=99,
+            detect_language=Mock(return_value=(None, {"en": 0.9, "fr": 0.1})),
+            decode=Mock(
+                return_value=DecodingResult(
+                    audio_features=torch.empty(0),
+                    language="en",
+                    tokens=[],
+                    text="",
+                    avg_logprob=-2.0,
+                    no_speech_prob=1.0,
+                    temperature=0.0,
+                    compression_ratio=0.0,
+                )
+            ),
+        )
+        return model, mel
+
+    return make
+
+
+@pytest.mark.parametrize(
+    "clips,start,end",
+    [
+        ("35,40", 3500, 4000),
+        ([35.0, 40.0], 3500, 4000),
+        ("0,10", 0, 1000),
+        ("5,40", 500, 3500),
+        ("35", 3500, 6500),
+        ([35.0], 3500, 6500),
+        ("35,60", 3500, 6500),
+        ("35,40,45,50", 3500, 4000),
+        ("0,0,35,40", 3500, 4000),
+        ("40,35,45,50", 4500, 5000),
+    ],
+)
+def test_language_detection_uses_first_clip(make_transcription, clips, start, end):
+    model, mel = make_transcription()
+
+    result = transcribe_module.transcribe(
+        model, torch.empty(0), clip_timestamps=clips, fp16=False, verbose=None
+    )
+
+    model.detect_language.assert_called_once()
+    detected_mel = model.detect_language.call_args.args[0]
+    assert torch.equal(detected_mel, pad_or_trim(mel[:, start:end], N_FRAMES))
+    assert result["language"] == "en"
+    assert model.decode.called
+    assert all(call.args[1].language == "en" for call in model.decode.call_args_list)
+
+
+@pytest.mark.parametrize("content_frames", [1200, 6000])
+@pytest.mark.parametrize("clips", [None, "", "0", [0.0]])
+def test_whole_file_language_detection_is_unchanged(
+    make_transcription, content_frames, clips
+):
+    model, mel = make_transcription(content_frames)
+    options = {} if clips is None else {"clip_timestamps": clips}
+
+    transcribe_module.transcribe(
+        model, torch.empty(0), fp16=False, verbose=None, **options
+    )
+
+    # Preserve the existing audio-domain silence padding for short whole-file inputs.
+    detected_mel = model.detect_language.call_args.args[0]
+    assert torch.equal(detected_mel, mel[:, :N_FRAMES])
+
+
+@pytest.mark.parametrize("multilingual,language", [(True, "fr"), (False, None)])
+def test_language_detection_can_be_skipped(make_transcription, multilingual, language):
+    model, _ = make_transcription()
+    model.is_multilingual = multilingual
+
+    result = transcribe_module.transcribe(
+        model,
+        torch.empty(0),
+        clip_timestamps="35,40",
+        language=language,
+        fp16=False,
+        verbose=None,
+    )
+
+    model.detect_language.assert_not_called()
+    assert result["language"] == (language or "en")
+
+
+@pytest.mark.parametrize("clips", ["5,5", "0,0,35,35", [40.0, 35.0, 50.0, 50.0]])
+def test_empty_clips_preserve_language_detection_fallback(make_transcription, clips):
+    model, mel = make_transcription()
+
+    transcribe_module.transcribe(
+        model, torch.empty(0), clip_timestamps=clips, fp16=False, verbose=None
+    )
+
+    assert torch.equal(model.detect_language.call_args.args[0], mel[:, :N_FRAMES])
+    model.decode.assert_not_called()

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -113,7 +113,8 @@ def transcribe(
 
     clip_timestamps: Union[str, List[float]]
         Comma-separated list start,end,start,end,... timestamps (in seconds) of clips to process.
-        The last end timestamp defaults to the end of the file.
+        The last end timestamp defaults to the end of the file. Automatic language detection
+        uses the first non-empty clip.
 
     hallucination_silence_threshold: Optional[float]
         When word_timestamps is True, skip silent periods longer than this threshold (in seconds)
@@ -140,15 +141,33 @@ def transcribe(
     content_frames = mel.shape[-1] - N_FRAMES
     content_duration = float(content_frames * HOP_LENGTH / SAMPLE_RATE)
 
+    if isinstance(clip_timestamps, str):
+        clip_timestamps = [
+            float(ts) for ts in (clip_timestamps.split(",") if clip_timestamps else [])
+        ]
+    seek_points: List[int] = [round(ts * FRAMES_PER_SECOND) for ts in clip_timestamps]
+    if len(seek_points) == 0:
+        seek_points.append(0)
+    if len(seek_points) % 2 == 1:
+        seek_points.append(content_frames)
+    seek_clips: List[Tuple[int, int]] = list(zip(seek_points[::2], seek_points[1::2]))
+
     if decode_options.get("language", None) is None:
         if not model.is_multilingual:
             decode_options["language"] = "en"
         else:
             if verbose:
                 print(
-                    "Detecting language using up to the first 30 seconds. Use `--language` to specify the language"
+                    "Detecting language using up to the first 30 seconds of the first clip. Use `--language` to specify the language"
                 )
-            mel_segment = pad_or_trim(mel, N_FRAMES).to(model.device).to(dtype)
+            language_mel = mel
+            for clip_start, clip_end in seek_clips:
+                if clip_end > clip_start:
+                    # Keep the existing silence padding when the clip reaches EOF.
+                    mel_end = None if clip_end >= content_frames else clip_end
+                    language_mel = mel[:, clip_start:mel_end]
+                    break
+            mel_segment = pad_or_trim(language_mel, N_FRAMES).to(model.device).to(dtype)
             _, probs = model.detect_language(mel_segment)
             decode_options["language"] = max(probs, key=probs.get)
             if verbose is not None:
@@ -164,17 +183,6 @@ def transcribe(
         language=language,
         task=task,
     )
-
-    if isinstance(clip_timestamps, str):
-        clip_timestamps = [
-            float(ts) for ts in (clip_timestamps.split(",") if clip_timestamps else [])
-        ]
-    seek_points: List[int] = [round(ts * FRAMES_PER_SECOND) for ts in clip_timestamps]
-    if len(seek_points) == 0:
-        seek_points.append(0)
-    if len(seek_points) % 2 == 1:
-        seek_points.append(content_frames)
-    seek_clips: List[Tuple[int, int]] = list(zip(seek_points[::2], seek_points[1::2]))
 
     punctuation = "\"'“¿([{-\"'.。,，!！?？:：”)]}、"
 


### PR DESCRIPTION
Automatic language detection currently runs before `clip_timestamps` is parsed, so it always examines the start of the file. For example, `transcribe(audio, clip_timestamps="35,45")` detects language from seconds 0–30 even though transcription starts at second 35. An excluded lead-in can therefore determine the language used to decode the requested speech.

Move the existing clip parsing ahead of detection and use up to 30 seconds of the first non-empty interval, respecting its end boundary as well as its start. Keep the existing audio-domain silence padding for intervals reaching EOF, so ordinary whole-file detection is unchanged for both short and long recordings.

Explicit language selection, English-only models, and the existing fallback for an all-empty clip list are preserved. This still selects one language for the transcription; it does not introduce per-clip language switching.

### Tests

- 23 deterministic tests cover string/list inputs, both clip boundaries, the 30-second cap, an omitted final end, multiple clips, empty/reversed intervals, whole-file compatibility, and detection bypasses. Ten clip-selection cases failed on the original implementation.
- The repository's CPU CI test selection passes: **42 passed, 20 deselected**, including real `tiny` and `tiny.en` transcription with word timestamps. CUDA and larger-model cases were not run.
- Real-model smoke: prepend 35 seconds of silence to `tests/jfk.flac`, transcribe with `tiny` and `clip_timestamps="35"`, and verify English, expected speech text, and timestamps starting at 35 seconds. Both the old detection window and the fixed path detected English in this sample; it is a compatibility check, not a measured accuracy improvement.
- Black, isort, Flake8 with the repository's hook arguments, and `git diff --check` pass. No dependency changes.

```sh
pytest -q -k 'not test_transcribe or test_transcribe[tiny] or test_transcribe[tiny.en]' -m 'not requires_cuda'
black --check whisper/transcribe.py tests/test_language_detection.py
isort --check-only whisper/transcribe.py tests/test_language_detection.py
flake8 --max-line-length 88 --ignore E203,E501,W503,W504 whisper/transcribe.py tests/test_language_detection.py
```

Verified on Python 3.12.12 / PyTorch 2.5.1, CPU. The two test warnings are the expected CPU FP16-to-FP32 fallback.
