### PR TITLE
Add `preserve_marks` option to BasicTextNormalizer for Brahmic and other mark-based scripts

### DIFF
--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -1,6 +1,6 @@
 import pytest
 
-from whisper.normalizers import EnglishTextNormalizer
+from whisper.normalizers import BasicTextNormalizer, EnglishTextNormalizer
 from whisper.normalizers.english import (
     EnglishNumberNormalizer,
     EnglishSpellingNormalizer,
@@ -102,3 +102,43 @@ def test_text_normalizer():
         std("Mr. Park visited Assoc. Prof. Kim Jr.")
         == "mister park visited associate professor kim junior"
     )
+
+
+def test_basic_normalizer():
+    std = BasicTextNormalizer()
+    assert std("Hello, WORLD!") == "hello world "
+    assert std("Hello [inaudible] (laughs) world") == "hello world"
+    assert std("café") == "café"
+    assert BasicTextNormalizer(remove_diacritics=True)("café") == "cafe"
+
+
+def test_basic_normalizer_preserve_marks():
+    # In Brahmic scripts (and in Thai, Thaana, Arabic/Hebrew with vowel points),
+    # vowel signs and viramas are Unicode "Mark" characters that are part of the
+    # spelling of a word. The default normalizer replaces them with spaces, which
+    # splits every word into fragments; `preserve_marks=True` keeps them.
+    malayalam = "സ്ഥിതിഗതികൾ നേരെയാക്കുന്നതിന്"
+    hindi = "प्राचीन संस्कृतियों और जनजातियों"
+    tamil = "வணக்கம், நான் தமிழ் பேசுகிறேன்"
+    thai = "สวัสดีครับ ผมพูดภาษาไทย"
+
+    std = BasicTextNormalizer()
+    assert std(malayalam) == "സ ഥ ത ഗത കൾ ന ര യ ക ക ന നത ന "
+    assert std(hindi) == "प र च न स स क त य और जनज त य "
+
+    std = BasicTextNormalizer(preserve_marks=True)
+    assert std(malayalam) == malayalam
+    assert std(hindi) == hindi
+    assert std(tamil) == "வணக்கம் நான் தமிழ் பேசுகிறேன்"
+    assert std(thai) == thai
+
+    # symbols and punctuation are still removed, and letters are still lowercased
+    assert std("Hello, WORLD! ¿Qué tal?") == "hello world qué tal "
+    assert std("café") == "café"
+
+    # grapheme clusters stay intact when splitting letters
+    std = BasicTextNormalizer(preserve_marks=True, split_letters=True)
+    assert std("കേരളം") == "കേ ര ളം"
+
+    with pytest.raises(ValueError):
+        BasicTextNormalizer(remove_diacritics=True, preserve_marks=True)

--- a/whisper/normalizers/basic.py
+++ b/whisper/normalizers/basic.py
@@ -1,5 +1,6 @@
 import re
 import unicodedata
+from functools import partial
 
 import regex
 
@@ -47,21 +48,42 @@ def remove_symbols_and_diacritics(s: str, keep=""):
     )
 
 
-def remove_symbols(s: str):
+def remove_symbols(s: str, preserve_marks: bool = False):
     """
     Replace any other markers, symbols, punctuations with a space, keeping diacritics
+
+    If `preserve_marks` is True, characters in the Unicode "Mark" categories
+    (Mn, Mc, Me) are kept instead of being replaced with a space. This matters for
+    scripts in which marks are part of the spelling of a word, such as the Brahmic
+    scripts (Devanagari, Bengali, Tamil, Malayalam, ...), Thai, Thaana, or Arabic
+    and Hebrew text with vowel points: replacing those marks with spaces splits
+    every word into fragments.
     """
+    categories = "SP" if preserve_marks else "MSP"
     return "".join(
-        " " if unicodedata.category(c)[0] in "MSP" else c
+        " " if unicodedata.category(c)[0] in categories else c
         for c in unicodedata.normalize("NFKC", s)
     )
 
 
 class BasicTextNormalizer:
-    def __init__(self, remove_diacritics: bool = False, split_letters: bool = False):
-        self.clean = (
-            remove_symbols_and_diacritics if remove_diacritics else remove_symbols
-        )
+    def __init__(
+        self,
+        remove_diacritics: bool = False,
+        split_letters: bool = False,
+        preserve_marks: bool = False,
+    ):
+        if remove_diacritics and preserve_marks:
+            raise ValueError(
+                "`preserve_marks` cannot be combined with `remove_diacritics`"
+            )
+
+        if remove_diacritics:
+            self.clean = remove_symbols_and_diacritics
+        elif preserve_marks:
+            self.clean = partial(remove_symbols, preserve_marks=True)
+        else:
+            self.clean = remove_symbols
         self.split_letters = split_letters
 
     def __call__(self, s: str):


### PR DESCRIPTION
## Problem

`BasicTextNormalizer` replaces every character whose Unicode category starts with `M` (Mark) with a space. In Brahmic scripts (Malayalam, Hindi/Devanagari, Tamil, Bengali, Telugu, Kannada, ...), and also in Thai, Thaana and Arabic/Hebrew text with vowel points, the vowel signs and viramas are `Mc`/`Mn` marks that are part of the spelling of a word. The normalizer therefore splits every word into fragments:

```python
>>> from whisper.normalizers import BasicTextNormalizer
>>> BasicTextNormalizer()("സ്ഥിതിഗതികൾ നേരെയാക്കുന്നതിന്")   # Malayalam
'സ ഥ ത ഗത കൾ ന ര യ ക ക ന നത ന '
>>> BasicTextNormalizer()("प्राचीन संस्कृतियों और जनजातियों")   # Hindi
'प र च न स स क त य और जनज त य '
```

Word error rates computed on this output are effectively character-level and not comparable with other systems. This was reported in discussion #858 and has been written up externally (Deepgram, "Breaking Brahmic: How OpenAI's Text Cleaning Hides Whisper's True Word Error Rate for Many South Asian Languages"; kavyamanohar.com, "Indian Languages and Text Normalization"). The docstring of `remove_symbols` already says "keeping diacritics", which is not what happens for these scripts.

## Change

- `remove_symbols(s, preserve_marks=False)`: when `preserve_marks=True`, characters in categories `Mn`/`Mc`/`Me` are kept; symbols (`S*`) and punctuation (`P*`) are still replaced with a space.
- `BasicTextNormalizer(preserve_marks=False)`: new keyword argument that routes to the above. Combining it with `remove_diacritics=True` raises `ValueError`, since the two options contradict each other.
- Tests for `BasicTextNormalizer` (there were none), including Malayalam, Hindi, Tamil and Thai cases and the `split_letters` interaction (grapheme clusters stay intact: `കേരളം` -> `കേ ര ളം`).

```python
>>> BasicTextNormalizer(preserve_marks=True)("സ്ഥിതിഗതികൾ നേരെയാക്കുന്നതിന്")
'സ്ഥിതിഗതികൾ നേരെയാക്കുന്നതിന്'
```

## Compatibility

The default behaviour is unchanged, so the numbers reported in the paper (Appendix C describes the M/S/P replacement) remain reproducible; users evaluating Brahmic-script languages opt in explicitly. The parameter name matches the one used by the community `whisper_normalizer` package, so code written against that package works unchanged with this option.

Ran `black`, `isort` and `flake8` with the repository's pre-commit settings; `pytest tests/test_normalizer.py` passes.