### PR TITLE
Raise on unsupported task instead of silently translating

### DIFF
--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -32,3 +32,17 @@ def test_split_on_unicode():
 
     assert words == [" elle", " est", " l", "'", "\ufffd", "é", "rit", "oire"]
     assert word_tokens == [[8404], [871], [287], [6], [246], [526], [3210], [20378]]
+
+
+def test_invalid_task_raises():
+    # any task other than the supported ones must fail loudly instead of
+    # silently behaving like "translate"
+    for bad_task in ["transcrib", "Transcribe", "TRANSLATE", "bogus", ""]:
+        with pytest.raises(ValueError, match="[Uu]nsupported task"):
+            get_tokenizer(multilingual=True, language="en", task=bad_task)
+
+
+def test_valid_tasks_still_work():
+    for task in ["transcribe", "translate", "lang_id", None]:
+        tokenizer = get_tokenizer(multilingual=True, language="en", task=task)
+        assert tokenizer.sot in tokenizer.sot_sequence

--- a/whisper/tokenizer.py
+++ b/whisper/tokenizer.py
@@ -379,6 +379,9 @@ def get_tokenizer(
             else:
                 raise ValueError(f"Unsupported language: {language}")
 
+    if task is not None and task not in {"transcribe", "translate", "lang_id"}:
+        raise ValueError(f"Unsupported task: {task}")
+
     if multilingual:
         encoding_name = "multilingual"
         language = language or "en"


### PR DESCRIPTION
Any `task` value other than `"transcribe"` (a typo like `"transcrib"`, wrong case like `"Transcribe"`, or any other string) silently behaves as `"translate"`, producing output in the wrong language with no error. It comes from `transcribe if self.task == "transcribe" else translate` in the tokenizer, with no validation anywhere even though the contract is `Literal["transcribe", "translate", None]`.

This adds a `ValueError` in `get_tokenizer`, next to the existing language check, and keeps `"lang_id"` working since decoding branches on it. Regression tests included; `test_tokenizer.py`, `test_audio.py`, and `test_normalizer.py` all pass.