### PR TITLE
Fix CLI crash on --threads None

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,50 @@
+import importlib
+
+transcribe_mod = importlib.import_module("whisper.transcribe")
+from whisper.transcribe import cli
+
+
+def test_cli_threads_none_does_not_crash(monkeypatch, tmp_path):
+    """`--threads None` parses to None via optional_int; cli() must not crash on it."""
+    monkeypatch.setattr("whisper.load_model", lambda *a, **k: object())
+    monkeypatch.setattr(
+        transcribe_mod,
+        "transcribe",
+        lambda model, audio, **kwargs: {"text": "", "segments": [], "language": "en"},
+    )
+    monkeypatch.setattr(
+        transcribe_mod,
+        "get_writer",
+        lambda fmt, out_dir: (lambda result, audio_path, **kw: None),
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "whisper",
+            "dummy.wav",
+            "--threads",
+            "None",
+            "--output_dir",
+            str(tmp_path),
+        ],
+    )
+    cli()  # must not raise TypeError: '>' not supported between 'NoneType' and 'int'
+
+
+def test_cli_threads_zero_still_works(monkeypatch, tmp_path):
+    """Default `--threads 0` behavior is unchanged (no set_num_threads call)."""
+    monkeypatch.setattr("whisper.load_model", lambda *a, **k: object())
+    monkeypatch.setattr(
+        transcribe_mod,
+        "transcribe",
+        lambda model, audio, **kwargs: {"text": "", "segments": [], "language": "en"},
+    )
+    monkeypatch.setattr(
+        transcribe_mod,
+        "get_writer",
+        lambda fmt, out_dir: (lambda result, audio_path, **kw: None),
+    )
+    monkeypatch.setattr(
+        "sys.argv", ["whisper", "dummy.wav", "--output_dir", str(tmp_path)]
+    )
+    cli()

--- a/whisper/transcribe.py
+++ b/whisper/transcribe.py
@@ -587,7 +587,7 @@ def cli():
     else:
         temperature = [temperature]
 
-    if (threads := args.pop("threads")) > 0:
+    if (threads := args.pop("threads")) is not None and threads > 0:
         torch.set_num_threads(threads)
 
     from . import load_model


### PR DESCRIPTION
Passing `--threads None` to the CLI crashes with an unhandled TypeError instead of running.

Bug report
- Repro (no model or GPU needed): `whisper dummy.wav --threads None`
- The `--threads` option is parsed with `optional_int`, which maps the string `"None"` to Python `None`. But `cli()` then runs `if (threads := args.pop("threads")) > 0:`, and `None > 0` raises `TypeError: '>' not supported between instances of 'NoneType' and 'int'` (whisper/transcribe.py). So the CLI's own converter produces a value its own next line cannot handle.
- Expected: `None` behaves like the default and leaves torch thread settings untouched.
- Actual: full traceback, transcription never starts.

Fix
- One-line guard: only compare when threads `is not None`, i.e. `if (threads := args.pop("threads")) is not None and threads > 0:`. Behavior for 0/positive values is unchanged.

Verification (CPU-only, no model downloads)
- New tests/test_cli.py drives the real `cli()` with a mocked model: `--threads None` failed before the fix with the exact TypeError above and passes after; default threads behavior covered too.
- Neighbors: tests/test_cli.py + tests/test_tokenizer.py (8 passed), tests/test_normalizer.py (all pass), tests/test_audio.py (pass). tests/test_timing.py CPU tests pass; only pre-existing requires_cuda cases fail (no GPU on this machine). tests/test_transcribe.py needs model downloads, skipped.
- Dup search: no open or closed upstream PR covers `--threads None` (checked open PRs and searched all states for "threads": #278 added the flag, #2845 and #1511 are unrelated thread-safety work). This is also a different area from my open PR #2852 (task validation in the tokenizer).